### PR TITLE
Take path by AsRef<Path>.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -49,9 +49,9 @@ fn filter_nones(params: Json) -> Json {
 
 impl Client {
     /// Creates a new client
-    pub fn new(sockname: &Path) -> Client {
+    pub fn new<P: AsRef<Path>>(sockname: P) -> Client {
         Client {
-            sockname: sockname.to_path_buf(),
+            sockname: sockname.as_ref().to_path_buf(),
             nonce: Arc::new(Mutex::new(0)),
         }
     }

--- a/src/lightningrpc.rs
+++ b/src/lightningrpc.rs
@@ -43,7 +43,7 @@ impl LightningRPC {
     /// * `sockname` - Path of UNIX socket to connect to, by default lightningd will create a
     /// socket named `.lightning/lightning-rpc` in the home directory of the user running
     /// lightningd.
-    pub fn new(sockname: &Path) -> LightningRPC {
+    pub fn new<P: AsRef<Path>>(sockname: P) -> LightningRPC {
         LightningRPC {
             client: client::Client::new(sockname),
         }


### PR DESCRIPTION
This is more idiomatic and nicer for clients. The change is
backward-compatible.

Resolves #3 