### PR TITLE
Use serde_json instead of strason and other refactorings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ readme = "README.md"
 [dependencies]
 serde = "1"
 serde_derive = "1"
-strason = "0.4"
+serde_json = "1.0"

--- a/examples/ex_1.rs
+++ b/examples/ex_1.rs
@@ -8,7 +8,7 @@ fn main() {
     let sock = env::home_dir().unwrap().join(".lightning/lightning-rpc");
     println!("Using socket {}", sock.display());
 
-    let mut client = LightningRPC::new(&sock);
+    let client = LightningRPC::new(&sock);
 
     println!("getinfo result: {:?}", client.getinfo().unwrap());
 

--- a/examples/ex_1.rs
+++ b/examples/ex_1.rs
@@ -16,7 +16,7 @@ fn main() {
         println!(
             "feerates {}: {:?}",
             style,
-            client.feerates(style.to_string()).unwrap()
+            client.feerates(style).unwrap()
         );
     }
 }

--- a/examples/lowlevel_1.rs
+++ b/examples/lowlevel_1.rs
@@ -1,9 +1,6 @@
 extern crate clightningrpc;
-extern crate strason;
 
 use std::env;
-
-use strason::Json;
 
 use clightningrpc::{client, requests, responses};
 
@@ -11,11 +8,11 @@ fn main() {
     let sock = env::home_dir().unwrap().join(".lightning/lightning-rpc");
     println!("Using socket {}", sock.display());
     let client = client::Client::new(&sock);
-    let params = Json::from_serialize(requests::GetInfo {}).unwrap();
-    let request = client.build_request("getinfo".to_string(), params);
+    let method = "getinfo";
+    let params = requests::GetInfo {};
     match client
-        .send_request(&request)
-        .and_then(|res| res.into_result::<responses::GetInfo>())
+        .send_request(method, params)
+        .and_then(|res: clightningrpc::Response<responses::GetInfo>| res.into_result())
     {
         Ok(d) => {
             println!("Ok! {:?}", d);

--- a/examples/lowlevel_2.rs
+++ b/examples/lowlevel_2.rs
@@ -1,9 +1,7 @@
 extern crate clightningrpc;
-extern crate strason;
+extern crate serde_json;
 
 use std::env;
-
-use strason::Json;
 
 use clightningrpc::{client, requests, responses};
 
@@ -12,13 +10,14 @@ fn main() {
     println!("Using socket {}", sock.display());
     let client = client::Client::new(&sock);
     for style in &["perkb", "perkw"] {
-        let params = Json::from_serialize(requests::FeeRates {
+        let method = "feerates";
+        let params = requests::FeeRates {
             style: style,
-        }).unwrap();
-        let request = client.build_request("feerates".to_string(), params);
+        };
+
         match client
-            .send_request(&request)
-            .and_then(|res| res.into_result::<responses::FeeRates>())
+            .send_request(method, params)
+            .and_then(|res: clightningrpc::Response<responses::FeeRates>| res.into_result())
         {
             Ok(d) => {
                 println!("Ok! {:?}", d);

--- a/examples/lowlevel_2.rs
+++ b/examples/lowlevel_2.rs
@@ -13,7 +13,7 @@ fn main() {
     let client = client::Client::new(&sock);
     for style in &["perkb", "perkw"] {
         let params = Json::from_serialize(requests::FeeRates {
-            style: style.to_string(),
+            style: style,
         }).unwrap();
         let request = client.build_request("feerates".to_string(), params);
         match client

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,13 +19,12 @@
 //! and parsing responses
 //!
 
-use std::io::Write;
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use strason::Json;
+use serde::{Serialize, de::DeserializeOwned};
+use serde_json::{Deserializer, to_writer};
 
 use super::{Request, Response};
 use error::Error;
@@ -34,23 +33,7 @@ use error::Error;
 #[derive(Debug)]
 pub struct Client {
     sockpath: PathBuf,
-    nonce: Arc<Mutex<u64>>,
     timeout: Option<Duration>,
-}
-
-/// Filter out top-level parameters with value None, this is used for handling optional
-/// parameters correctly as c-lightning expects.
-///
-/// This function panics if passed Json isn't a json object.
-fn filter_nones(params: Json) -> Json {
-    let rv = params
-        .object()
-        .unwrap()
-        .iter()
-        .filter(|(_, v)| v.null().is_none())
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect::<Vec<_>>();
-    Json::from(rv)
 }
 
 impl Client {
@@ -58,7 +41,6 @@ impl Client {
     pub fn new<P: AsRef<Path>>(sockpath: P) -> Client {
         Client {
             sockpath: sockpath.as_ref().to_path_buf(),
-            nonce: Arc::new(Mutex::new(0)),
             timeout: None,
         }
     }
@@ -69,62 +51,32 @@ impl Client {
     }
 
     /// Sends a request to a client
-    pub fn send_request(&self, request: &Request) -> Result<Response, Error> {
-        // Build request
-        let request_raw = Json::from_serialize(request)?.to_bytes();
-
+    pub fn send_request<S: Serialize, D: DeserializeOwned>(&self, method: &str, params: S) -> Result<Response<D>, Error> {
         // Setup connection
         let mut stream = UnixStream::connect(&self.sockpath)?;
         stream.set_read_timeout(self.timeout)?;
         stream.set_write_timeout(self.timeout)?;
 
-        stream.write_all(&request_raw)?;
+        to_writer(&mut stream, &Request {
+            method,
+            params,
+            id: 0, // we always open a new connection, so we don't have to care about the nonce
+            jsonrpc: "2.0",
+        })?;
 
-        let response: Response = Json::from_reader(&mut stream)?.into_deserialize()?;
-        if response.jsonrpc != None && response.jsonrpc != Some(From::from("2.0")) {
+        let response: Response<D> = Deserializer::from_reader(&mut stream)
+            .into_iter()
+            .next()
+            .map_or(Err(Error::NoErrorOrResult), |res| Ok(res?))?;
+        if response.jsonrpc.as_ref().map_or(false, |version| version != "2.0") {
             return Err(Error::VersionMismatch);
         }
-        if response.id != request.id {
+
+        // nonce will always be 0
+        if response.id != 0 {
             return Err(Error::NonceMismatch);
         }
 
         Ok(response)
-    }
-
-    /// Builds a request
-    pub fn build_request(&self, name: String, params: Json) -> Request {
-        let mut nonce = self.nonce.lock().unwrap();
-        *nonce += 1;
-
-        Request {
-            method: name,
-            params: filter_nones(params),
-            id: From::from(*nonce),
-            jsonrpc: Some(String::from("2.0")),
-        }
-    }
-
-    /// Accessor for the last-used nonce
-    pub fn last_nonce(&self) -> u64 {
-        *self.nonce.lock().unwrap()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use strason::Json;
-
-    #[test]
-    fn sanity() {
-        let client = Client::new("/tmp/socket/localhost");
-        assert_eq!(client.last_nonce(), 0);
-        let req1 =
-            client.build_request("test".to_owned(), Json::from(Vec::<(String, Json)>::new()));
-        assert_eq!(client.last_nonce(), 1);
-        let req2 =
-            client.build_request("test".to_owned(), Json::from(Vec::<(String, Json)>::new()));
-        assert_eq!(client.last_nonce(), 2);
-        assert!(req1 != req2);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,7 +23,8 @@ use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use serde::{Serialize, de::DeserializeOwned};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 use serde_json::{Deserializer, to_writer};
 
 use super::{Request, Response};

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,7 @@
 use std::io;
 use std::{error, fmt};
 
-use strason::{self, Json};
+use serde_json;
 
 /// Known lightningd error codes.
 ///
@@ -85,7 +85,7 @@ pub enum RpcErrorCode {
 #[derive(Debug)]
 pub enum Error {
     /// Json error
-    Json(strason::Error),
+    Json(serde_json::Error),
     /// IO Error
     Io(io::Error),
     /// Error response
@@ -98,8 +98,8 @@ pub enum Error {
     VersionMismatch,
 }
 
-impl From<strason::Error> for Error {
-    fn from(e: strason::Error) -> Error {
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Error {
         Error::Json(e)
     }
 }
@@ -154,144 +154,5 @@ pub struct RpcError {
     /// A string describing the error
     pub message: String,
     /// Additional data specific to the error
-    pub data: Option<Json>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use strason::Json;
-    use Response;
-
-    /// Standard error responses, as described at at
-    /// http://www.jsonrpc.org/specification#error_object
-    ///
-    /// # Documentation Copyright
-    /// Copyright (C) 2007-2010 by the JSON-RPC Working Group
-    ///
-    /// This document and translations of it may be used to implement JSON-RPC, it
-    /// may be copied and furnished to others, and derivative works that comment
-    /// on or otherwise explain it or assist in its implementation may be prepared,
-    /// copied, published and distributed, in whole or in part, without restriction
-    /// of any kind, provided that the above copyright notice and this paragraph
-    /// are included on all such copies and derivative works. However, this document
-    /// itself may not be modified in any way.
-    ///
-    /// The limited permissions granted above are perpetual and will not be revoked.
-    ///
-    /// This document and the information contained herein is provided "AS IS" and
-    /// ALL WARRANTIES, EXPRESS OR IMPLIED are DISCLAIMED, INCLUDING BUT NOT LIMITED
-    /// TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY
-    /// RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
-    /// PARTICULAR PURPOSE.
-    ///
-    #[derive(Debug)]
-    pub enum StandardError {
-        /// Invalid JSON was received by the server.
-        /// An error occurred on the server while parsing the JSON text.
-        ParseError,
-        /// The JSON sent is not a valid Request object.
-        InvalidRequest,
-        /// The method does not exist / is not available.
-        MethodNotFound,
-        /// Invalid method parameter(s).
-        InvalidParams,
-        /// Internal JSON-RPC error.
-        InternalError,
-    }
-    use self::StandardError::*;
-
-    /// Create a standard error responses
-    pub fn standard_error(code: StandardError, data: Option<Json>) -> RpcError {
-        match code {
-            StandardError::ParseError => RpcError {
-                code: -32700,
-                message: "Parse error".to_string(),
-                data: data,
-            },
-            StandardError::InvalidRequest => RpcError {
-                code: -32600,
-                message: "Invalid Request".to_string(),
-                data: data,
-            },
-            StandardError::MethodNotFound => RpcError {
-                code: -32601,
-                message: "Method not found".to_string(),
-                data: data,
-            },
-            StandardError::InvalidParams => RpcError {
-                code: -32602,
-                message: "Invalid params".to_string(),
-                data: data,
-            },
-            StandardError::InternalError => RpcError {
-                code: -32603,
-                message: "Internal error".to_string(),
-                data: data,
-            },
-        }
-    }
-
-    /// Converts a Rust `Result` to a JSONRPC response object
-    pub fn result_to_response(result: Result<Json, RpcError>, id: Json) -> Response {
-        match result {
-            Ok(data) => Response {
-                result: Some(data),
-                error: None,
-                id: id,
-                jsonrpc: Some(String::from("2.0")),
-            },
-            Err(err) => Response {
-                result: None,
-                error: Some(err),
-                id: id,
-                jsonrpc: Some(String::from("2.0")),
-            },
-        }
-    }
-
-    #[test]
-    fn test_parse_error() {
-        let resp = result_to_response(Err(standard_error(ParseError, None)), From::from(1));
-        assert!(resp.result.is_none());
-        assert!(resp.error.is_some());
-        assert_eq!(resp.id, From::from(1));
-        assert_eq!(resp.error.unwrap().code, -32700);
-    }
-
-    #[test]
-    fn test_invalid_request() {
-        let resp = result_to_response(Err(standard_error(InvalidRequest, None)), From::from(1));
-        assert!(resp.result.is_none());
-        assert!(resp.error.is_some());
-        assert_eq!(resp.id, From::from(1));
-        assert_eq!(resp.error.unwrap().code, -32600);
-    }
-
-    #[test]
-    fn test_method_not_found() {
-        let resp = result_to_response(Err(standard_error(MethodNotFound, None)), From::from(1));
-        assert!(resp.result.is_none());
-        assert!(resp.error.is_some());
-        assert_eq!(resp.id, From::from(1));
-        assert_eq!(resp.error.unwrap().code, -32601);
-    }
-
-    #[test]
-    fn test_invalid_params() {
-        let resp = result_to_response(Err(standard_error(InvalidParams, None)), From::from("123"));
-        assert!(resp.result.is_none());
-        assert!(resp.error.is_some());
-        assert_eq!(resp.id, From::from("123"));
-        assert_eq!(resp.error.unwrap().code, -32602);
-    }
-
-    #[test]
-    fn test_internal_error() {
-        let resp = result_to_response(Err(standard_error(InternalError, None)), From::from(-1));
-        assert!(resp.result.is_none());
-        assert!(resp.error.is_some());
-        assert_eq!(resp.id, From::from(-1));
-        assert_eq!(resp.error.unwrap().code, -32603);
-    }
+    pub data: Option<serde_json::Value>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate strason;
+extern crate serde_json;
 
 pub mod client;
 pub mod common;
@@ -44,162 +44,51 @@ pub mod lightningrpc;
 pub mod requests;
 pub mod responses;
 
-use strason::Json;
 // Re-export error type
 pub use error::Error;
 // Re-export high-level connection type
 pub use lightningrpc::LightningRPC;
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
 /// A JSONRPC request object
-pub struct Request {
+pub struct Request<'f, T: Serialize> {
     /// The name of the RPC call
-    pub method: String,
+    pub method: &'f str,
     /// Parameters to the RPC call
-    pub params: Json,
+    pub params: T,
     /// Identifier for this Request, which should appear in the response
-    pub id: Json,
+    pub id: u64,
     /// jsonrpc field, MUST be "2.0"
-    pub jsonrpc: Option<String>,
+    pub jsonrpc: &'f str,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 /// A JSONRPC response object
-pub struct Response {
+pub struct Response<T> {
     /// A result if there is one, or null
-    pub result: Option<Json>,
+    pub result: Option<T>,
     /// An error if there is one, or null
     pub error: Option<error::RpcError>,
     /// Identifier for this Request, which should match that of the request
-    pub id: Json,
+    pub id: u64,
     /// jsonrpc field, MUST be "2.0"
     pub jsonrpc: Option<String>,
 }
 
-impl Response {
-    /// Extract the result from a response
-    pub fn result<T: serde::de::DeserializeOwned>(&self) -> Result<T, Error> {
-        if let Some(ref e) = self.error {
-            return Err(Error::Rpc(e.clone()));
-        }
-        match self.result {
-            Some(ref res) => res.clone().into_deserialize().map_err(Error::Json),
-            None => Err(Error::NoErrorOrResult),
-        }
-    }
-
+impl<T> Response<T> {
     /// Extract the result from a response, consuming the response
-    pub fn into_result<T: serde::de::DeserializeOwned>(self) -> Result<T, Error> {
+    pub fn into_result(self) -> Result<T, Error> {
         if let Some(e) = self.error {
             return Err(Error::Rpc(e));
         }
 
-        match self.result {
-            Some(ref res) => res.clone().into_deserialize().map_err(Error::Json),
-            None => Err(Error::NoErrorOrResult),
-        }
-    }
-
-    /// Return the RPC error, if there was one, but do not check the result
-    pub fn check_error(self) -> Result<(), Error> {
-        if let Some(e) = self.error {
-            Err(Error::Rpc(e))
-        } else {
-            Ok(())
-        }
+        self.result.ok_or(Error::NoErrorOrResult)
     }
 
     /// Returns whether or not the `result` field is empty
     pub fn is_none(&self) -> bool {
         self.result.is_none()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::error::RpcError;
-    use super::{Request, Response};
-    use strason::Json;
-
-    #[test]
-    fn request_serialize_round_trip() {
-        let original = Request {
-            method: "test".to_owned(),
-            params: From::from(vec![
-                ("a".to_string(), From::from(())),
-                ("b".to_string(), From::from(false)),
-                ("c".to_string(), From::from(true)),
-                ("d".to_string(), From::from("test2")),
-            ]),
-            id: From::from("69"),
-            jsonrpc: Some(String::from("2.0")),
-        };
-
-        let ser = Json::from_serialize(&original).unwrap();
-        let des = ser.into_deserialize().unwrap();
-
-        assert_eq!(original, des);
-    }
-
-    #[test]
-    fn response_serialize_round_trip() {
-        let original_err = RpcError {
-            code: -77,
-            message: "test4".to_owned(),
-            data: Some(From::from(true)),
-        };
-
-        let original = Response {
-            result: Some(From::<Vec<Json>>::from(vec![
-                From::from(()),
-                From::from(false),
-                From::from(true),
-                From::from("test2"),
-            ])),
-            error: Some(original_err),
-            id: From::from(101),
-            jsonrpc: Some(String::from("2.0")),
-        };
-
-        let ser = Json::from_serialize(&original).unwrap();
-        let des = ser.into_deserialize().unwrap();
-
-        assert_eq!(original, des);
-    }
-
-    #[test]
-    fn response_is_none() {
-        let joanna = Response {
-            result: Some(From::from(true)),
-            error: None,
-            id: From::from(81),
-            jsonrpc: Some(String::from("2.0")),
-        };
-
-        let bill = Response {
-            result: None,
-            error: None,
-            id: From::from(66),
-            jsonrpc: Some(String::from("2.0")),
-        };
-
-        assert!(!joanna.is_none());
-        assert!(bill.is_none());
-    }
-
-    #[test]
-    fn response_extract() {
-        let obj = vec!["Mary", "had", "a", "little", "lamb"];
-        let response = Response {
-            result: Some(Json::from_serialize(&obj).unwrap()),
-            error: None,
-            id: From::from(()),
-            jsonrpc: Some(String::from("2.0")),
-        };
-        let recovered1: Vec<String> = response.result().unwrap();
-        assert!(response.clone().check_error().is_ok());
-        let recovered2: Vec<String> = response.into_result().unwrap();
-        assert_eq!(obj, recovered1);
-        assert_eq!(obj, recovered2);
     }
 }

--- a/src/lightningrpc.rs
+++ b/src/lightningrpc.rs
@@ -51,13 +51,13 @@ impl LightningRPC {
     }
 
     /// Get reference to the low-level client connection
-    pub fn client(&mut self) -> &mut client::Client {
-        &mut self.client
+    pub fn client(&self) -> &client::Client {
+        &self.client
     }
 
     /// Generic call function for RPC calls.
     fn call<T: Serialize, U: DeserializeOwned>(
-        &mut self,
+        &self,
         method: &str,
         input: T,
     ) -> Result<U, Error> {
@@ -69,49 +69,49 @@ impl LightningRPC {
     }
 
     /// Show information about this node.
-    pub fn getinfo(&mut self) -> Result<responses::GetInfo, Error> {
+    pub fn getinfo(&self) -> Result<responses::GetInfo, Error> {
         self.call("getinfo", requests::GetInfo {})
     }
 
     /// Return feerate estimates, either satoshi-per-kw ({style} perkw) or satoshi-per-kb ({style}
     /// perkb).
-    pub fn feerates(&mut self, style: &str) -> Result<responses::FeeRates, Error> {
+    pub fn feerates(&self, style: &str) -> Result<responses::FeeRates, Error> {
         self.call("feerates", requests::FeeRates { style: style })
     }
 
     /// Show node {id} (or all, if no {id}), in our local network view.
-    pub fn listnodes(&mut self, id: Option<&str>) -> Result<responses::ListNodes, Error> {
+    pub fn listnodes(&self, id: Option<&str>) -> Result<responses::ListNodes, Error> {
         self.call("listnodes", requests::ListNodes { id })
     }
 
     /// Show channel {short_channel_id} (or all known channels, if no {short_channel_id}).
     pub fn listchannels(
-        &mut self,
+        &self,
         short_channel_id: Option<&str>,
     ) -> Result<responses::ListChannels, Error> {
         self.call("listchannels", requests::ListChannels { short_channel_id })
     }
 
     /// List available commands, or give verbose help on one command.
-    pub fn help(&mut self, command: Option<&str>) -> Result<responses::Help, Error> {
+    pub fn help(&self, command: Option<&str>) -> Result<responses::Help, Error> {
         self.call("help", requests::Help { command })
     }
 
     /// Show logs, with optional log {level} (info|unusual|debug|io).
-    pub fn getlog(&mut self, level: Option<&str>) -> Result<responses::GetLog, Error> {
+    pub fn getlog(&self, level: Option<&str>) -> Result<responses::GetLog, Error> {
         self.call("getlog", requests::GetLog { level })
     }
 
     /// List all configuration options, or with [config], just that one.
     /// Because of the dynamic nature of the returned object, unlike the other methods, this
     /// returns a HashMap (from &str to Json) instead of a structure.
-    pub fn listconfigs(&mut self, config: Option<&str>) -> Result<responses::ListConfigs, Error> {
+    pub fn listconfigs(&self, config: Option<&str>) -> Result<responses::ListConfigs, Error> {
         self.call("listconfigs", requests::ListConfigs { config })
     }
 
     /// Show current peers, if {level} is set, include {log}s.
     pub fn listpeers(
-        &mut self,
+        &self,
         id: Option<&str>,
         level: Option<&str>,
     ) -> Result<responses::ListPeers, Error> {
@@ -120,7 +120,7 @@ impl LightningRPC {
 
     /// Show invoice {label} (or all, if no {label)).
     pub fn listinvoices(
-        &mut self,
+        &self,
         label: Option<&str>,
     ) -> Result<responses::ListInvoices, Error> {
         self.call("listinvoices", requests::ListInvoices { label })
@@ -129,7 +129,7 @@ impl LightningRPC {
     /// Create an invoice for {msatoshi} with {label} and {description} with
     /// optional {expiry} seconds (default 1 hour).
     pub fn invoice(
-        &mut self,
+        &self,
         msatoshi: u64,
         label: &str,
         description: &str,
@@ -149,7 +149,7 @@ impl LightningRPC {
     /// Create an invoice for {msatoshi} with {label} and {description} with
     /// optional {expiry} seconds (default 1 hour).
     pub fn delinvoice(
-        &mut self,
+        &self,
         label: &str,
         status: &str,
     ) -> Result<responses::DelInvoice, Error> {
@@ -159,7 +159,7 @@ impl LightningRPC {
     /// Delete all expired invoices that expired as of given {maxexpirytime} (a UNIX epoch time),
     /// or all expired invoices if not specified.
     pub fn delexpiredinvoice(
-        &mut self,
+        &self,
         maxexpirytime: Option<u64>,
     ) -> Result<responses::DelExpiredInvoice, Error> {
         self.call(
@@ -172,7 +172,7 @@ impl LightningRPC {
     /// or disable autoclean if 0. Clean up expired invoices that have expired for {expired_by}
     /// seconds (default 86400).
     pub fn autocleaninvoice(
-        &mut self,
+        &self,
         cycle_seconds: Option<u64>,
         expired_by: Option<u64>,
     ) -> Result<responses::AutoCleanInvoice, Error> {
@@ -188,14 +188,14 @@ impl LightningRPC {
     /// Wait for the next invoice to be paid, after {lastpay_index}.
     /// (if supplied)
     pub fn waitanyinvoice(
-        &mut self,
+        &self,
         lastpay_index: Option<u64>,
     ) -> Result<responses::WaitAnyInvoice, Error> {
         self.call("waitanyinvoice", requests::WaitAnyInvoice { lastpay_index })
     }
 
     /// Wait for an incoming payment matching the invoice with {label}.
-    pub fn waitinvoice(&mut self, label: &str) -> Result<responses::WaitInvoice, Error> {
+    pub fn waitinvoice(&self, label: &str) -> Result<responses::WaitInvoice, Error> {
         self.call("waitinvoice", requests::WaitInvoice { label })
     }
 
@@ -205,7 +205,7 @@ impl LightningRPC {
     ///
     /// * `bolt11` - A string that holds the payment information in bolt11 format.
     /// * `options` - Options for this payment. Use `Default::default()` to not pass any options.
-    pub fn pay(&mut self, bolt11: &str, options: PayOptions) -> Result<responses::Pay, Error> {
+    pub fn pay(&self, bolt11: &str, options: PayOptions) -> Result<responses::Pay, Error> {
         self.call(
             "pay",
             requests::Pay {
@@ -223,7 +223,7 @@ impl LightningRPC {
 
     /// Send along {route} in return for preimage of {payment_hash}, with optional {description}.
     pub fn sendpay(
-        &mut self,
+        &self,
         route: Vec<common::RouteItem>,
         payment_hash: &str,
         description: Option<&str>,
@@ -242,7 +242,7 @@ impl LightningRPC {
 
     /// Wait for payment attempt on {payment_hash} to succeed or fail, but only up to {timeout} seconds.
     pub fn waitsendpay(
-        &mut self,
+        &self,
         payment_hash: &str,
         timeout: u64,
     ) -> Result<responses::WaitSendPay, Error> {
@@ -257,7 +257,7 @@ impl LightningRPC {
 
     /// Show outgoing payments.
     pub fn listpayments(
-        &mut self,
+        &self,
         bolt11: Option<&str>,
         payment_hash: Option<&str>,
     ) -> Result<responses::ListPayments, Error> {
@@ -272,7 +272,7 @@ impl LightningRPC {
 
     /// Decode {bolt11}, using {description} if necessary.
     pub fn decodepay(
-        &mut self,
+        &self,
         bolt11: &str,
         description: Option<&str>,
     ) -> Result<responses::DecodePay, Error> {
@@ -290,7 +290,7 @@ impl LightningRPC {
     /// up to {fuzzpercent} (0.0 -> 100.0, default 5.0) using {seed} as an arbitrary-size string
     /// seed.
     pub fn getroute(
-        &mut self,
+        &self,
         id: &str,
         msatoshi: u64,
         riskfactor: f64,
@@ -316,7 +316,7 @@ impl LightningRPC {
     /// Connect to {id} at {host} (which can end in ':port' if not default). {id} can also be of
     /// the form id@host.
     pub fn connect(
-        &mut self,
+        &self,
         id: &str,
         host: Option<&str>,
     ) -> Result<responses::Connect, Error> {
@@ -324,7 +324,7 @@ impl LightningRPC {
     }
 
     /// Disconnect from peer with {peer_id}.
-    pub fn disconnect(&mut self, id: &str) -> Result<responses::Disconnect, Error> {
+    pub fn disconnect(&self, id: &str) -> Result<responses::Disconnect, Error> {
         self.call("disconnect", requests::Disconnect { id })
     }
 
@@ -337,7 +337,7 @@ impl LightningRPC {
     /// `AmountOrAll::All` to spend all available funds
     /// * `feerate` - optional feerate to use for Bitcoin transaction
     pub fn fundchannel(
-        &mut self,
+        &self,
         id: &str,
         satoshi: requests::AmountOrAll,
         feerate: Option<u64>,
@@ -356,7 +356,7 @@ impl LightningRPC {
     /// (default false) is true, force a unilateral close after {timeout} seconds (default 30),
     /// otherwise just schedule a mutual close later and fail after timing out.
     pub fn close(
-        &mut self,
+        &self,
         id: &str,
         force: Option<bool>,
         timeout: Option<u64>,
@@ -366,7 +366,7 @@ impl LightningRPC {
 
     /// Send {peerid} a ping of length {len} (default 128) asking for {pongbytes} (default 128).
     pub fn ping(
-        &mut self,
+        &self,
         id: &str,
         len: Option<u64>,
         pongbytes: Option<u64>,
@@ -375,7 +375,7 @@ impl LightningRPC {
     }
 
     /// Show available funds from the internal wallet.
-    pub fn listfunds(&mut self) -> Result<responses::ListFunds, Error> {
+    pub fn listfunds(&self) -> Result<responses::ListFunds, Error> {
         self.call("listfunds", requests::ListFunds {})
     }
 
@@ -388,7 +388,7 @@ impl LightningRPC {
     /// `AmountOrAll::All` to spend all available funds
     /// * `feerate` - optional feerate to use for Bitcoin transaction
     pub fn withdraw(
-        &mut self,
+        &self,
         destination: &str,
         satoshi: requests::AmountOrAll,
         feerate: Option<u64>,
@@ -404,12 +404,12 @@ impl LightningRPC {
     }
 
     /// Get a new {bech32, p2sh-segwit} address to fund a channel (default is bech32).
-    pub fn newaddr(&mut self, addresstype: Option<&str>) -> Result<responses::NewAddr, Error> {
+    pub fn newaddr(&self, addresstype: Option<&str>) -> Result<responses::NewAddr, Error> {
         self.call("newaddr", requests::NewAddr { addresstype })
     }
 
     /// Shut down the lightningd process.
-    pub fn stop(&mut self) -> Result<responses::Stop, Error> {
+    pub fn stop(&self) -> Result<responses::Stop, Error> {
         self.call("stop", requests::Stop {})
     }
 }

--- a/src/lightningrpc.rs
+++ b/src/lightningrpc.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use strason::Json;
 
 use client;
 use common;
@@ -61,11 +60,9 @@ impl LightningRPC {
         method: &str,
         input: T,
     ) -> Result<U, Error> {
-        let params = Json::from_serialize(input)?;
-        let request = self.client.build_request(method.to_string(), params);
         self.client
-            .send_request(&request)
-            .and_then(|res| res.into_result::<U>())
+            .send_request(method, input)
+            .and_then(|res| res.into_result())
     }
 
     /// Show information about this node.

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -222,8 +222,8 @@ impl Serialize for AmountOrAll {
     where
         S: Serializer,
     {
-        match &self {
-            AmountOrAll::Amount(a) => serializer.serialize_u64(*a),
+        match *self {
+            AmountOrAll::Amount(a) => serializer.serialize_u64(a),
             AmountOrAll::All => serializer.serialize_str("all"),
         }
     }

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -31,43 +31,51 @@ pub struct FeeRates<'a> {
 /// 'listnodes' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ListNodes<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<&'a str>,
 }
 
 /// 'listchannels' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ListChannels<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub short_channel_id: Option<&'a str>,
 }
 
 /// 'help' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Help<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<&'a str>,
 }
 
 /// 'getlog' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GetLog<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub level: Option<&'a str>,
 }
 
 /// 'listconfigs' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ListConfigs<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<&'a str>,
 }
 
 /// 'listpeers' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ListPeers<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub level: Option<&'a str>,
 }
 
 /// 'listinvoices' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ListInvoices<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<&'a str>,
 }
 
@@ -77,6 +85,7 @@ pub struct Invoice<'a> {
     pub msatoshi: u64,
     pub label: &'a str,
     pub description: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expiry: Option<u64>,
 }
 
@@ -90,19 +99,23 @@ pub struct DelInvoice<'a> {
 /// 'delexpiredinvoice' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DelExpiredInvoice {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub maxexpirytime: Option<u64>,
 }
 
 /// 'autocleaninvoice' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AutoCleanInvoice {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cycle_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expired_by: Option<u64>,
 }
 
 /// 'waitanyinvoice' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WaitAnyInvoice {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lastpay_index: Option<u64>,
 }
 
@@ -116,12 +129,19 @@ pub struct WaitInvoice<'a> {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Pay<'a> {
     pub bolt11: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub msatoshi: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub riskfactor: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub maxfeepercent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub exemptfee: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_for: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub maxdelay: Option<u64>,
 }
 
@@ -130,7 +150,9 @@ pub struct Pay<'a> {
 pub struct SendPay<'a> {
     pub route: Vec<common::RouteItem>,
     pub payment_hash: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub msatoshi: Option<u64>,
 }
 
@@ -144,7 +166,9 @@ pub struct WaitSendPay<'a> {
 /// 'listpayments' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ListPayments<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bolt11: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_hash: Option<&'a str>,
 }
 
@@ -152,6 +176,7 @@ pub struct ListPayments<'a> {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DecodePay<'a> {
     pub bolt11: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<&'a str>,
 }
 
@@ -161,9 +186,13 @@ pub struct GetRoute<'a> {
     pub id: &'a str,
     pub msatoshi: u64,
     pub riskfactor: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cltv: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fromid: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fuzzpercent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub seed: Option<&'a str>,
 }
 
@@ -171,6 +200,7 @@ pub struct GetRoute<'a> {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Connect<'a> {
     pub id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub host: Option<&'a str>,
 }
 
@@ -204,6 +234,7 @@ impl Serialize for AmountOrAll {
 pub struct FundChannel<'a> {
     pub id: &'a str,
     pub satoshi: AmountOrAll,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub feerate: Option<u64>,
 }
 
@@ -211,7 +242,9 @@ pub struct FundChannel<'a> {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Close<'a> {
     pub id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub force: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u64>,
 }
 
@@ -219,7 +252,9 @@ pub struct Close<'a> {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Ping<'a> {
     pub id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub len: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pongbytes: Option<u64>,
 }
 
@@ -232,45 +267,17 @@ pub struct ListFunds {}
 pub struct Withdraw<'a> {
     pub destination: &'a str,
     pub satoshi: AmountOrAll,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub feerate: Option<u64>,
 }
 
 /// 'newaddr' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NewAddr<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub addresstype: Option<&'a str>,
 }
 
 /// 'stop' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Stop {}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use strason::Json;
-
-    #[test]
-    fn fundchannel() {
-        // Tests AmountOrAll as well as basic JSON serialization
-        let result = Json::from_serialize(FundChannel {
-            id: "12345",
-            satoshi: AmountOrAll::Amount(123456),
-            feerate: None,
-        }).unwrap();
-        assert_eq!(
-            result.to_string(),
-            r#"{"id": "12345", "satoshi": 123456, "feerate": null}"#
-        );
-
-        let result = Json::from_serialize(FundChannel {
-            id: "12345",
-            satoshi: AmountOrAll::All,
-            feerate: Some(123),
-        }).unwrap();
-        assert_eq!(
-            result.to_string(),
-            r#"{"id": "12345", "satoshi": "all", "feerate": 123}"#
-        );
-    }
-}

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -22,69 +22,69 @@ use common;
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GetInfo {}
 
-/// 'feerates' command
+/// 'aeerates' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct FeeRates {
-    pub style: String,
+pub struct FeeRates<'a> {
+    pub style: &'a str,
 }
 
 /// 'listnodes' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListNodes {
-    pub id: Option<String>,
+pub struct ListNodes<'a> {
+    pub id: Option<&'a str>,
 }
 
 /// 'listchannels' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListChannels {
-    pub short_channel_id: Option<String>,
+pub struct ListChannels<'a> {
+    pub short_channel_id: Option<&'a str>,
 }
 
 /// 'help' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Help {
-    pub command: Option<String>,
+pub struct Help<'a> {
+    pub command: Option<&'a str>,
 }
 
 /// 'getlog' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct GetLog {
-    pub level: Option<String>,
+pub struct GetLog<'a> {
+    pub level: Option<&'a str>,
 }
 
 /// 'listconfigs' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListConfigs {
-    pub config: Option<String>,
+pub struct ListConfigs<'a> {
+    pub config: Option<&'a str>,
 }
 
 /// 'listpeers' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListPeers {
-    pub id: Option<String>,
-    pub level: Option<String>,
+pub struct ListPeers<'a> {
+    pub id: Option<&'a str>,
+    pub level: Option<&'a str>,
 }
 
 /// 'listinvoices' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListInvoices {
-    pub label: Option<String>,
+pub struct ListInvoices<'a> {
+    pub label: Option<&'a str>,
 }
 
 /// 'invoice' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Invoice {
+pub struct Invoice<'a> {
     pub msatoshi: u64,
-    pub label: String,
-    pub description: String,
+    pub label: &'a str,
+    pub description: &'a str,
     pub expiry: Option<u64>,
 }
 
 /// 'delinvoice' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct DelInvoice {
-    pub label: String,
-    pub status: String,
+pub struct DelInvoice<'a> {
+    pub label: &'a str,
+    pub status: &'a str,
 }
 
 /// 'delexpiredinvoice' command
@@ -108,16 +108,16 @@ pub struct WaitAnyInvoice {
 
 /// 'waitinvoice' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct WaitInvoice {
-    pub label: String,
+pub struct WaitInvoice<'a> {
+    pub label: &'a str,
 }
 
 /// 'pay' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Pay {
-    pub bolt11: String,
+pub struct Pay<'a> {
+    pub bolt11: &'a str,
     pub msatoshi: Option<u64>,
-    pub description: Option<String>,
+    pub description: Option<&'a str>,
     pub riskfactor: Option<f64>,
     pub maxfeepercent: Option<f64>,
     pub exemptfee: Option<u64>,
@@ -127,57 +127,57 @@ pub struct Pay {
 
 /// 'sendpay' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct SendPay {
+pub struct SendPay<'a> {
     pub route: Vec<common::RouteItem>,
-    pub payment_hash: String,
-    pub description: Option<String>,
+    pub payment_hash: &'a str,
+    pub description: Option<&'a str>,
     pub msatoshi: Option<u64>,
 }
 
 /// 'waitsendpay' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct WaitSendPay {
-    pub payment_hash: String,
+pub struct WaitSendPay<'a> {
+    pub payment_hash: &'a str,
     pub timeout: u64,
 }
 
 /// 'listpayments' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListPayments {
-    pub bolt11: Option<String>,
-    pub payment_hash: Option<String>,
+pub struct ListPayments<'a> {
+    pub bolt11: Option<&'a str>,
+    pub payment_hash: Option<&'a str>,
 }
 
 /// 'decodepay' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct DecodePay {
-    pub bolt11: String,
-    pub description: Option<String>,
+pub struct DecodePay<'a> {
+    pub bolt11: &'a str,
+    pub description: Option<&'a str>,
 }
 
 /// 'getroute' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct GetRoute {
-    pub id: String,
+pub struct GetRoute<'a> {
+    pub id: &'a str,
     pub msatoshi: u64,
     pub riskfactor: f64,
     pub cltv: Option<u64>,
-    pub fromid: Option<String>,
+    pub fromid: Option<&'a str>,
     pub fuzzpercent: Option<f64>,
-    pub seed: Option<String>,
+    pub seed: Option<&'a str>,
 }
 
 /// 'connect' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Connect {
-    pub id: String,
-    pub host: Option<String>,
+pub struct Connect<'a> {
+    pub id: &'a str,
+    pub host: Option<&'a str>,
 }
 
 /// 'disconnect' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Disconnect {
-    pub id: String,
+pub struct Disconnect<'a> {
+    pub id: &'a str,
 }
 
 /// enum type that can either hold an integer amount, or All
@@ -199,26 +199,26 @@ impl Serialize for AmountOrAll {
     }
 }
 
-/// 'fundchannel' command
+/// 'aundchannel' command
 #[derive(Debug, Clone, Serialize)]
-pub struct FundChannel {
-    pub id: String,
+pub struct FundChannel<'a> {
+    pub id: &'a str,
     pub satoshi: AmountOrAll,
     pub feerate: Option<u64>,
 }
 
 /// 'close' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Close {
-    pub id: String,
+pub struct Close<'a> {
+    pub id: &'a str,
     pub force: Option<bool>,
     pub timeout: Option<u64>,
 }
 
 /// 'ping' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Ping {
-    pub id: String,
+pub struct Ping<'a> {
+    pub id: &'a str,
     pub len: Option<u64>,
     pub pongbytes: Option<u64>,
 }
@@ -229,16 +229,16 @@ pub struct ListFunds {}
 
 /// 'withdraw' command
 #[derive(Debug, Clone, Serialize)]
-pub struct Withdraw {
-    pub destination: String,
+pub struct Withdraw<'a> {
+    pub destination: &'a str,
     pub satoshi: AmountOrAll,
     pub feerate: Option<u64>,
 }
 
 /// 'newaddr' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct NewAddr {
-    pub addresstype: Option<String>,
+pub struct NewAddr<'a> {
+    pub addresstype: Option<&'a str>,
 }
 
 /// 'stop' command
@@ -254,7 +254,7 @@ mod tests {
     fn fundchannel() {
         // Tests AmountOrAll as well as basic JSON serialization
         let result = Json::from_serialize(FundChannel {
-            id: "12345".to_string(),
+            id: "12345",
             satoshi: AmountOrAll::Amount(123456),
             feerate: None,
         }).unwrap();
@@ -264,7 +264,7 @@ mod tests {
         );
 
         let result = Json::from_serialize(FundChannel {
-            id: "12345".to_string(),
+            id: "12345",
             satoshi: AmountOrAll::All,
             feerate: Some(123),
         }).unwrap();

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -15,7 +15,6 @@
 #![allow(missing_docs)]
 //! Structures representing responses to API calls
 use std::collections::HashMap;
-use strason::Json;
 
 use common;
 
@@ -25,7 +24,7 @@ pub struct NetworkAddress {
     #[serde(rename = "type")]
     pub type_: String,
     pub address: String,
-    pub port: String,
+    pub port: u16,
 }
 
 /// 'getinfo' command
@@ -139,7 +138,7 @@ pub struct GetLog {
 }
 
 /// 'listconfigs' command
-pub type ListConfigs = HashMap<String, Json>;
+pub type ListConfigs = HashMap<String, serde_json::Value>;
 
 /// Sub-structure for channel in 'listpeers'
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -15,16 +15,30 @@
 #![allow(missing_docs)]
 //! Structures representing responses to API calls
 use std::collections::HashMap;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 use common;
 
 /// structure for network addresses
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct NetworkAddress {
-    #[serde(rename = "type")]
-    pub type_: String,
-    pub address: String,
-    pub port: u16,
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum NetworkAddress {
+    Ipv4 {
+        address: Ipv4Addr,
+        port: u16,
+    },
+    Ipv6 {
+        address: Ipv6Addr,
+        port: u16,
+    },
+    Torv2 {
+        address: String,
+        port: u16,
+    },
+    Torv3 {
+        address: String,
+        port: u16,
+    },
 }
 
 /// 'getinfo' command

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -14,6 +14,7 @@
 //
 #![allow(missing_docs)]
 //! Structures representing responses to API calls
+use serde_json;
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
 


### PR DESCRIPTION
- Use borrowed strings for requests (avoids annoying `to_owned` calls)
- Don't require `mut` references for requests
- Replace `strason` with `serde_json` and adapt the request code accordingly
- Remove nonce counting since every request uses its own connection
- Remove some dead code and some tests testing serialization, which is now serde's problem imo (it seems silly to test if serde does its job right)
- Make the data structures less stringly typed where possible (if I missed anything please tell me)

@stevenroose since you seemed interested, maybe you can have a look at the changes too?