### PR TITLE
Async API proof of concept

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clightningrpc"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Wladimir J. van der Laan <laanwj@gmail.com>"]
 license = "CC0-1.0"
 homepage = "https://github.com/laanwj/rust-clightning-rpc"
@@ -14,3 +14,10 @@ edition = "2018"
 serde = "1"
 serde_derive = "1"
 serde_json = "1.0"
+
+futures = "0.3"
+
+[dev-dependencies]
+tokio = { version = "0.2", features = [ "full" ] }
+tokio-util = { version = "0.3", features = [ "compat" ] }
+futures = { version = "0.3", features = [ "io-compat" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/laanwj/rust-clightning-rpc.git"
 description = "Crate that provides an RPC binding from rust code to the c-lightning daemon"
 keywords = [ "protocol", "rpc", "lightning", "bitcoin" ]
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 serde = "1"

--- a/examples/async_ex_1.rs
+++ b/examples/async_ex_1.rs
@@ -1,0 +1,24 @@
+extern crate clightningrpc;
+
+use std::env;
+
+use tokio::net::UnixStream;
+use tokio_util::compat::Tokio02AsyncReadCompatExt;
+
+use clightningrpc::aio::LightningRPC;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let sock = env::home_dir().unwrap().join(".lightning/lightning-rpc");
+    println!("Using socket {}", sock.display());
+    let stream = UnixStream::connect(sock).await?;
+    let mut client = LightningRPC::new(stream.compat());
+
+    println!("getinfo result: {:#?}", client.getinfo().await?);
+
+    for style in &["perkb", "perkw"] {
+        println!("feerates {}: {:#?}", style, client.feerates(style).await?);
+    }
+
+    Ok(())
+}

--- a/examples/async_lowlevel_1.rs
+++ b/examples/async_lowlevel_1.rs
@@ -1,0 +1,44 @@
+extern crate clightningrpc;
+
+use std::env;
+
+use tokio::net::UnixStream;
+
+use tokio_util::compat::Tokio02AsyncReadCompatExt;
+
+use clightningrpc::aio::client;
+use clightningrpc::{requests, responses};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let sock = env::home_dir().unwrap().join(".lightning/lightning-rpc");
+    println!("Using socket {}", sock.display());
+    let stream = UnixStream::connect(sock).await?;
+    let mut client = client::Client::new(stream.compat());
+
+    match client
+        .send_request("getinfo", requests::GetInfo {})
+        .await
+        .and_then(|res: clightningrpc::Response<responses::GetInfo>| res.into_result())
+    {
+        Ok(d) => {
+            println!("Ok! {:#?}", d);
+        }
+        Err(e) => {
+            println!("Error! {}", e);
+        }
+    }
+    match client
+        .send_request("listfunds", requests::ListFunds {})
+        .await
+        .and_then(|res: clightningrpc::Response<responses::ListFunds>| res.into_result())
+    {
+        Ok(d) => {
+            println!("Ok! {:#?}", d);
+        }
+        Err(e) => {
+            println!("Error! {}", e);
+        }
+    }
+    Ok(())
+}

--- a/src/aio/client.rs
+++ b/src/aio/client.rs
@@ -1,0 +1,95 @@
+// Rust JSON-RPC Library
+// Written by
+//     Andrew Poelstra <apoelstra@wpsoftware.net>
+//     Wladimir J. van der Laan <laanwj@gmail.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Async client support
+//!
+//! TODO: write comment
+//!
+
+use futures::io::BufReader;
+use futures::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, ReadHalf};
+use futures::io::{AsyncWrite, AsyncWriteExt, WriteHalf};
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::{from_str, to_string};
+
+use crate::error::Error;
+use crate::{Request, Response};
+
+/// A handle to a remote JSONRPC server
+#[derive(Debug)]
+pub struct Client<U: AsyncRead + AsyncWrite> {
+    read_sock: BufReader<ReadHalf<U>>,
+    write_sock: WriteHalf<U>,
+    next_id: u64,
+}
+
+impl<U> Client<U>
+where
+    U: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Creates a new client
+    pub fn new(sock: U) -> Self {
+        let (r, w) = sock.split();
+        Client {
+            read_sock: BufReader::new(r),
+            write_sock: w,
+            next_id: 0,
+        }
+    }
+
+    /// Sends a request to a client
+    pub async fn send_request<S: Serialize, D: DeserializeOwned>(
+        &mut self,
+        method: &str,
+        params: S,
+    ) -> Result<Response<D>, Error> {
+        let expected_id = self.next_id;
+        self.next_id += 1;
+
+        let serialized = to_string(&Request {
+            method,
+            params,
+            id: expected_id,
+            jsonrpc: "2.0",
+        })?;
+
+        self.write_sock.write_all(serialized.as_bytes()).await?;
+
+        let mut line = String::new();
+        loop {
+            self.read_sock.read_line(&mut line).await?;
+            if !line.chars().all(|c| c.is_whitespace()) {
+                break;
+            }
+        }
+        let response: Response<D> = from_str(&line)?;
+
+        if response
+            .jsonrpc
+            .as_ref()
+            .map_or(false, |version| version != "2.0")
+        {
+            return Err(Error::VersionMismatch);
+        }
+
+        if response.id != expected_id {
+            return Err(Error::NonceMismatch);
+        }
+
+        Ok(response)
+    }
+}

--- a/src/aio/lightningrpc.rs
+++ b/src/aio/lightningrpc.rs
@@ -1,0 +1,382 @@
+//! High-level async interface to c-lightning RPC
+use futures::io::{AsyncRead, AsyncWrite};
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::aio::client;
+use crate::common;
+use crate::error::Error;
+use crate::requests;
+use crate::responses;
+use crate::lightningrpc::PayOptions;
+
+/// Structure providing a high-level interface to the c-lightning daemon RPC
+#[derive(Debug)]
+pub struct LightningRPC<U: AsyncRead + AsyncWrite> {
+    client: client::Client<U>,
+}
+
+impl<U> LightningRPC<U>
+where
+    U: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Create a new connection from a UNIX socket stream.
+    ///
+    /// # Arguments
+    ///
+    /// * `stream` - TODO
+    pub fn new(stream: U) -> Self
+    {
+        LightningRPC {
+            client: client::Client::new(stream),
+        }
+    }
+
+    /// Get reference to the low-level client connection
+    pub fn client(&mut self) -> &mut client::Client<U> {
+        &mut self.client
+    }
+
+    /// Generic call function for RPC calls.
+    async fn call<T: Serialize, D: DeserializeOwned>(&mut self, method: &str, input: T) -> Result<D, Error> {
+        self.client
+            .send_request(method, input)
+            .await
+            .and_then(|res| res.into_result())
+    }
+
+    /// Show information about this node.
+    pub async fn getinfo(&mut self) -> Result<responses::GetInfo, Error> {
+        self.call("getinfo", requests::GetInfo {}).await
+    }
+
+    /// Return feerate estimates, either satoshi-per-kw ({style} perkw) or satoshi-per-kb ({style}
+    /// perkb).
+    pub async fn feerates(&mut self, style: &str) -> Result<responses::FeeRates, Error> {
+        self.call("feerates", requests::FeeRates { style: style }).await
+    }
+
+    /// Show node {id} (or all, if no {id}), in our local network view.
+    pub async fn listnodes(&mut self, id: Option<&str>) -> Result<responses::ListNodes, Error> {
+        self.call("listnodes", requests::ListNodes { id }).await
+    }
+
+    /// Show channel {short_channel_id} (or all known channels, if no {short_channel_id}).
+    pub async fn listchannels(
+        &mut self,
+        short_channel_id: Option<&str>,
+    ) -> Result<responses::ListChannels, Error> {
+        self.call("listchannels", requests::ListChannels { short_channel_id }).await
+    }
+
+    /// List available commands, or give verbose help on one command.
+    pub async fn help(&mut self, command: Option<&str>) -> Result<responses::Help, Error> {
+        self.call("help", requests::Help { command }).await
+    }
+
+    /// Show logs, with optional log {level} (info|unusual|debug|io).
+    pub async fn getlog(&mut self, level: Option<&str>) -> Result<responses::GetLog, Error> {
+        self.call("getlog", requests::GetLog { level }).await
+    }
+
+    /// List all configuration options, or with [config], just that one.
+    /// Because of the dynamic nature of the returned object, unlike the other methods, this
+    /// returns a HashMap (from &str to Json) instead of a structure.
+    pub async fn listconfigs(&mut self, config: Option<&str>) -> Result<responses::ListConfigs, Error> {
+        self.call("listconfigs", requests::ListConfigs { config }).await
+    }
+
+    /// Show current peers, if {level} is set, include {log}s.
+    pub async fn listpeers(
+        &mut self,
+        id: Option<&str>,
+        level: Option<&str>,
+    ) -> Result<responses::ListPeers, Error> {
+        self.call("listpeers", requests::ListPeers { id, level }).await
+    }
+
+    /// Show invoice {label} (or all, if no {label)).
+    pub async fn listinvoices(&mut self, label: Option<&str>) -> Result<responses::ListInvoices, Error> {
+        self.call("listinvoices", requests::ListInvoices { label }).await
+    }
+
+    /// Create an invoice for {msatoshi} with {label} and {description} with
+    /// optional {expiry} seconds (default 1 hour).
+    pub async fn invoice(
+        &mut self,
+        msatoshi: u64,
+        label: &str,
+        description: &str,
+        expiry: Option<u64>,
+    ) -> Result<responses::Invoice, Error> {
+        self.call(
+            "invoice",
+            requests::Invoice {
+                msatoshi,
+                label,
+                description,
+                expiry,
+            },
+        ).await
+    }
+
+    /// Create an invoice for {msatoshi} with {label} and {description} with
+    /// optional {expiry} seconds (default 1 hour).
+    pub async fn delinvoice(&mut self, label: &str, status: &str) -> Result<responses::DelInvoice, Error> {
+        self.call("delinvoice", requests::DelInvoice { label, status }).await
+    }
+
+    /// Delete all expired invoices that expired as of given {maxexpirytime} (a UNIX epoch time),
+    /// or all expired invoices if not specified.
+    pub async fn delexpiredinvoice(
+        &mut self,
+        maxexpirytime: Option<u64>,
+    ) -> Result<responses::DelExpiredInvoice, Error> {
+        self.call(
+            "delexpiredinvoice",
+            requests::DelExpiredInvoice { maxexpirytime },
+        ).await
+    }
+
+    /// Set up autoclean of expired invoices. Perform cleanup every {cycle_seconds} (default 3600),
+    /// or disable autoclean if 0. Clean up expired invoices that have expired for {expired_by}
+    /// seconds (default 86400).
+    pub async fn autocleaninvoice(
+        &mut self,
+        cycle_seconds: Option<u64>,
+        expired_by: Option<u64>,
+    ) -> Result<responses::AutoCleanInvoice, Error> {
+        self.call(
+            "autocleaninvoice",
+            requests::AutoCleanInvoice {
+                cycle_seconds,
+                expired_by,
+            },
+        ).await
+    }
+
+    /// Wait for the next invoice to be paid, after {lastpay_index}.
+    /// (if supplied)
+    pub async fn waitanyinvoice(
+        &mut self,
+        lastpay_index: Option<u64>,
+    ) -> Result<responses::WaitAnyInvoice, Error> {
+        self.call("waitanyinvoice", requests::WaitAnyInvoice { lastpay_index }).await
+    }
+
+    /// Wait for an incoming payment matching the invoice with {label}.
+    pub async fn waitinvoice(&mut self, label: &str) -> Result<responses::WaitInvoice, Error> {
+        self.call("waitinvoice", requests::WaitInvoice { label }).await
+    }
+
+    /// Send a lightning payment.
+    ///
+    /// # Arguments
+    ///
+    /// * `bolt11` - A string that holds the payment information in bolt11 format.
+    /// * `options` - Options for this payment. Use `Default::default()` to not pass any options.
+    pub async fn pay<'a>(&mut self, bolt11: &str, options: PayOptions<'a>) -> Result<responses::Pay, Error> {
+        self.call(
+            "pay",
+            requests::Pay {
+                bolt11: bolt11,
+                msatoshi: options.msatoshi,
+                description: options.description,
+                riskfactor: options.riskfactor,
+                maxfeepercent: options.maxfeepercent,
+                exemptfee: options.exemptfee,
+                retry_for: options.retry_for,
+                maxdelay: options.maxdelay,
+            },
+        ).await
+    }
+
+    /// Send along {route} in return for preimage of {payment_hash}, with optional {description}.
+    pub async fn sendpay(
+        &mut self,
+        route: Vec<common::RouteItem>,
+        payment_hash: &str,
+        description: Option<&str>,
+        msatoshi: Option<u64>,
+    ) -> Result<responses::SendPay, Error> {
+        self.call(
+            "sendpay",
+            requests::SendPay {
+                route,
+                payment_hash,
+                description,
+                msatoshi,
+            },
+        ).await
+    }
+
+    /// Wait for payment attempt on {payment_hash} to succeed or fail, but only up to {timeout} seconds.
+    pub async fn waitsendpay(
+        &mut self,
+        payment_hash: &str,
+        timeout: u64,
+    ) -> Result<responses::WaitSendPay, Error> {
+        self.call(
+            "waitsendpay",
+            requests::WaitSendPay {
+                payment_hash,
+                timeout,
+            },
+        ).await
+    }
+
+    /// Show outgoing payments.
+    pub async fn listsendpays(
+        &mut self,
+        bolt11: Option<&str>,
+        payment_hash: Option<&str>,
+    ) -> Result<responses::ListSendPays, Error> {
+        self.call(
+            "listsendpays",
+            requests::ListSendPays {
+                bolt11,
+                payment_hash,
+            },
+        ).await
+    }
+
+    /// Decode {bolt11}, using {description} if necessary.
+    pub async fn decodepay(
+        &mut self,
+        bolt11: &str,
+        description: Option<&str>,
+    ) -> Result<responses::DecodePay, Error> {
+        self.call(
+            "decodepay",
+            requests::DecodePay {
+                bolt11,
+                description,
+            },
+        ).await
+    }
+
+    /// Show route to {id} for {msatoshi}, using {riskfactor} and optional {cltv} (default 9). If
+    /// specified search from {fromid} otherwise use this node as source. Randomize the route with
+    /// up to {fuzzpercent} (0.0 -> 100.0, default 5.0) using {seed} as an arbitrary-size string
+    /// seed.
+    pub async fn getroute(
+        &mut self,
+        id: &str,
+        msatoshi: u64,
+        riskfactor: f64,
+        cltv: Option<u64>,
+        fromid: Option<&str>,
+        fuzzpercent: Option<f64>,
+        seed: Option<&str>,
+    ) -> Result<responses::GetRoute, Error> {
+        self.call(
+            "getroute",
+            requests::GetRoute {
+                id,
+                msatoshi,
+                riskfactor,
+                cltv,
+                fromid,
+                fuzzpercent,
+                seed,
+            },
+        ).await
+    }
+
+    /// Connect to {id} at {host} (which can end in ':port' if not default). {id} can also be of
+    /// the form id@host.
+    pub async fn connect(&mut self, id: &str, host: Option<&str>) -> Result<responses::Connect, Error> {
+        self.call("connect", requests::Connect { id, host }).await
+    }
+
+    /// Disconnect from peer with {peer_id}.
+    pub async fn disconnect(&mut self, id: &str) -> Result<responses::Disconnect, Error> {
+        self.call("disconnect", requests::Disconnect { id }).await
+    }
+
+    /// Fund a new channel with another lightning node.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Id of node to fund a channel to
+    /// * `satoshi` - either `AmountOrAll::Amount(n)` for a given amount in satoshi units, or
+    /// `AmountOrAll::All` to spend all available funds
+    /// * `feerate` - optional feerate to use for Bitcoin transaction
+    pub async fn fundchannel(
+        &mut self,
+        id: &str,
+        satoshi: requests::AmountOrAll,
+        feerate: Option<u64>,
+    ) -> Result<responses::FundChannel, Error> {
+        self.call(
+            "fundchannel",
+            requests::FundChannel {
+                id,
+                satoshi,
+                feerate,
+            },
+        ).await
+    }
+
+    /// Close the channel with {id} (either peer ID, channel ID, or short channel ID). If {force}
+    /// (default false) is true, force a unilateral close after {timeout} seconds (default 30),
+    /// otherwise just schedule a mutual close later and fail after timing out.
+    pub async fn close(
+        &mut self,
+        id: &str,
+        force: Option<bool>,
+        timeout: Option<u64>,
+    ) -> Result<responses::Close, Error> {
+        self.call("close", requests::Close { id, force, timeout }).await
+    }
+
+    /// Send {peerid} a ping of length {len} (default 128) asking for {pongbytes} (default 128).
+    pub async fn ping(
+        &mut self,
+        id: &str,
+        len: Option<u64>,
+        pongbytes: Option<u64>,
+    ) -> Result<responses::Ping, Error> {
+        self.call("ping", requests::Ping { id, len, pongbytes }).await
+    }
+
+    /// Show available funds from the internal wallet.
+    pub async fn listfunds(&mut self) -> Result<responses::ListFunds, Error> {
+        self.call("listfunds", requests::ListFunds {}).await
+    }
+
+    /// Send to destination address via Bitcoin transaction.
+    ///
+    /// # Arguments
+    ///
+    /// * `destination` - Bitcoin address to send to
+    /// * `satoshi` - either `AmountOrAll::Amount(n)` for a given amount in satoshi units, or
+    /// `AmountOrAll::All` to spend all available funds
+    /// * `feerate` - optional feerate to use for Bitcoin transaction
+    pub async fn withdraw(
+        &mut self,
+        destination: &str,
+        satoshi: requests::AmountOrAll,
+        feerate: Option<u64>,
+    ) -> Result<responses::Withdraw, Error> {
+        self.call(
+            "withdraw",
+            requests::Withdraw {
+                destination,
+                satoshi,
+                feerate,
+            },
+        ).await
+    }
+
+    /// Get a new {bech32, p2sh-segwit} address to fund a channel (default is bech32).
+    pub async fn newaddr(&mut self, addresstype: Option<&str>) -> Result<responses::NewAddr, Error> {
+        self.call("newaddr", requests::NewAddr { addresstype }).await
+    }
+
+    /// Shut down the lightningd process.
+    pub async fn stop(&mut self) -> Result<responses::Stop, Error> {
+        self.call("stop", requests::Stop {}).await
+    }
+}

--- a/src/aio/mod.rs
+++ b/src/aio/mod.rs
@@ -1,0 +1,6 @@
+//! Async variants of both the high and low-level interfaces.
+
+pub mod client;
+pub mod lightningrpc;
+
+pub use lightningrpc::LightningRPC;

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ use serde::de::DeserializeOwned;
 use serde_json::{Deserializer, to_writer};
 
 use super::{Request, Response};
-use error::Error;
+use crate::error::Error;
 
 /// A handle to a remote JSONRPC server
 #[derive(Debug)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,10 @@
 #![allow(missing_docs)]
 //! Common structures between requests and responses
 
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+
 /// Sub-structure for route in 'pay', 'getroute' and 'sendpay'
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RouteItem {
@@ -8,4 +12,64 @@ pub struct RouteItem {
     pub channel: String,
     pub msatoshi: i64,
     pub delay: i64,
+}
+
+/// Type-safe millisatoshi wrapper
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MSat(pub u64);
+
+impl Serialize for MSat {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}msat", self.0))
+    }
+}
+
+struct MSatVisitor;
+
+impl<'d> de::Visitor<'d> for MSatVisitor {
+    type Value = MSat;
+
+    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        if !s.ends_with("msat") {
+            return Err(E::custom("missing msat suffix"));
+        }
+
+        let numpart = s
+            .get(0..(s.len() - 4))
+            .ok_or_else(|| E::custom("missing msat suffix"))?;
+
+        let res = u64::from_str(numpart).map_err(|_| E::custom("not a number"))?;
+        Ok(MSat(res))
+    }
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a string ending with \"msat\"")
+    }
+}
+
+impl<'d> Deserialize<'d> for MSat {
+    fn deserialize<D>(deserializer: D) -> Result<MSat, D::Error>
+    where
+        D: Deserializer<'d>,
+    {
+        deserializer.deserialize_str(MSatVisitor)
+    }
+}
+
+impl fmt::Debug for MSat {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}msat", self.0)
+    }
+}
+
+impl fmt::Display for MSat {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}msat", self.0)
+    }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,8 +10,12 @@ use std::str::FromStr;
 pub struct RouteItem {
     pub id: String,
     pub channel: String,
-    pub msatoshi: i64,
+    pub direction: Option<u64>,
+    pub amount_msat: MSat,
     pub delay: i64,
+    pub style: Option<String>,
+    pub blinding: Option<String>,
+    pub enctlv: Option<String>,
 }
 
 /// Type-safe millisatoshi wrapper

--- a/src/error.rs
+++ b/src/error.rs
@@ -133,6 +133,7 @@ impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Json(ref e) => Some(e),
+            Error::Io(ref e) => Some(e),
             _ => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ pub mod lightningrpc;
 pub mod requests;
 pub mod responses;
 
+pub mod aio;
+
 // Re-export error type
 pub use crate::error::Error;
 // Re-export high-level connection type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 
 //! Crate that provides an RPC binding from rust code to the c-lightning daemon
 //!
-//! This create provides both a high and a low-level interface.
+//! This crate provides both a high and a low-level interface.
 //! Most likely, you'll want to use the high-level interface through `LightningRPC`, as this is
 //! most convenient,
 //! but it is also possible to construct Request and Response objects manually and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,9 @@ pub mod requests;
 pub mod responses;
 
 // Re-export error type
-pub use error::Error;
+pub use crate::error::Error;
 // Re-export high-level connection type
-pub use lightningrpc::LightningRPC;
+pub use crate::lightningrpc::LightningRPC;
 
 use serde::Serialize;
 

--- a/src/lightningrpc.rs
+++ b/src/lightningrpc.rs
@@ -253,14 +253,14 @@ impl LightningRPC {
     }
 
     /// Show outgoing payments.
-    pub fn listpayments(
+    pub fn listsendpays(
         &self,
         bolt11: Option<&str>,
         payment_hash: Option<&str>,
-    ) -> Result<responses::ListPayments, Error> {
+    ) -> Result<responses::ListSendPays, Error> {
         self.call(
-            "listpayments",
-            requests::ListPayments {
+            "listsendpays",
+            requests::ListSendPays {
                 bolt11,
                 payment_hash,
             },

--- a/src/lightningrpc.rs
+++ b/src/lightningrpc.rs
@@ -4,11 +4,11 @@ use std::path::Path;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use client;
-use common;
-use error::Error;
-use requests;
-use responses;
+use crate::client;
+use crate::common;
+use crate::error::Error;
+use crate::requests;
+use crate::responses;
 
 /// Structure providing a high-level interface to the c-lightning daemon RPC
 #[derive(Debug)]

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -22,7 +22,7 @@ use crate::common;
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GetInfo {}
 
-/// 'aeerates' command
+/// 'feerates' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FeeRates<'a> {
     pub style: &'a str,

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -163,9 +163,9 @@ pub struct WaitSendPay<'a> {
     pub timeout: u64,
 }
 
-/// 'listpayments' command
+/// 'listsendpays' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListPayments<'a> {
+pub struct ListSendPays<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bolt11: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -16,7 +16,7 @@
 #![allow(missing_docs)]
 use serde::{Serialize, Serializer};
 
-use common;
+use crate::common;
 
 /// 'getinfo' command
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -18,7 +18,7 @@ use serde_json;
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use common;
+use crate::common;
 
 /// structure for network addresses
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::common;
+use crate::common::MSat;
 
 /// structure for network addresses
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -48,18 +49,33 @@ pub struct GetInfo {
     pub id: String,
     pub alias: String,
     pub color: String,
+    pub num_peers: u64,
+    pub num_pending_channels: u64,
+    pub num_active_channels: u64,
+    pub num_inactive_channels: u64,
     pub address: Vec<NetworkAddress>,
     pub binding: Vec<NetworkAddress>,
     pub version: String,
     pub blockheight: u64,
+    pub fees_collected_msat: MSat,
     pub network: String,
+    #[serde(rename = "lightning-dir")]
+    pub ligthning_dir: String,
+    pub warning_bitcoind_sync: Option<String>,
+    pub warning_lightningd_sync: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FeeRatesInner {
-    pub urgent: u64,
-    pub normal: u64,
-    pub slow: u64,
+    pub urgent: Option<u64>,
+    pub normal: Option<u64>,
+    pub slow: Option<u64>,
+    pub opening: u64,
+    pub mutual_close: u64,
+    pub unilateral_close: u64,
+    pub delayed_to_us: u64,
+    pub htlc_resolution: u64,
+    pub penalty: u64,
     pub min_acceptable: u64,
     pub max_acceptable: u64,
 }
@@ -69,6 +85,8 @@ pub struct FeeRatesOnchain {
     pub opening_channel_satoshis: u64,
     pub mutual_close_satoshis: u64,
     pub unilateral_close_satoshis: u64,
+    pub htlc_timeout_satoshis: u64,
+    pub htlc_success_satoshis: u64,
 }
 
 /// 'feerates' command
@@ -76,6 +94,7 @@ pub struct FeeRatesOnchain {
 pub struct FeeRates {
     pub perkb: Option<FeeRatesInner>,
     pub perkw: Option<FeeRatesInner>,
+    pub warning: Option<String>,
     pub onchain_fee_estimates: Option<FeeRatesOnchain>,
 }
 
@@ -86,7 +105,7 @@ pub struct ListNodesItem {
     pub alias: Option<String>,
     pub color: Option<String>,
     pub last_timestamp: Option<u64>,
-    pub global_features: Option<String>,
+    pub features: Option<String>,
     pub addresses: Option<Vec<NetworkAddress>>,
 }
 
@@ -103,13 +122,17 @@ pub struct ListChannelsItem {
     pub destination: String,
     pub short_channel_id: String,
     pub public: bool,
-    pub satoshis: u64,
-    pub flags: u64,
+    pub amount_msat: MSat,
+    pub message_flags: u64,
+    pub channel_flags: u64,
     pub active: bool,
     pub last_update: u64,
     pub base_fee_millisatoshi: u64,
     pub fee_per_millionth: u64,
     pub delay: u64,
+    pub htlc_minimum_msat: MSat,
+    pub htlc_maximum_msat: MSat,
+    pub features: String,
 }
 
 /// 'listchannels' command
@@ -122,25 +145,28 @@ pub struct ListChannels {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HelpItem {
     pub command: String,
+    pub category: String,
     pub description: String,
+    pub verbose: String,
 }
 
 /// 'help' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Help {
     pub help: Option<Vec<HelpItem>>,
-    pub verbose: Option<String>,
 }
 
-/// Sub-structure for 'getlog' item
+/// Sub-structure for 'getlog' and 'listpeers' item
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LogEntry {
     #[serde(rename = "type")]
     pub type_: String,
     pub num_skipped: Option<u64>,
     pub time: Option<String>,
+    pub node_id: Option<String>,
     pub source: Option<String>,
     pub log: Option<String>,
+    pub data: Option<String>,
 }
 
 /// 'getlog' command
@@ -155,46 +181,56 @@ pub struct GetLog {
 /// 'listconfigs' command
 pub type ListConfigs = HashMap<String, serde_json::Value>;
 
+/// Sub-structure for htlcs in 'listpeers'
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Htlc {
+    pub direction: String,
+    pub id: u64,
+    pub amount_msat: MSat,
+    pub expiry: u64,
+    pub payment_hash: String,
+    pub state: String,
+    pub local_trimmed: Option<bool>,
+}
+
 /// Sub-structure for channel in 'listpeers'
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Channel {
     pub state: String,
+    pub scratch_txid: Option<String>,
     pub owner: Option<String>,
     pub short_channel_id: Option<String>,
+    pub direction: Option<u64>,
     pub channel_id: String,
     pub funding_txid: String,
-    pub msatoshi_to_us: u64,
-    pub msatoshi_to_us_min: u64,
-    pub msatoshi_to_us_max: u64,
-    pub msatoshi_total: u64,
-    pub dust_limit_satoshis: u64,
-    pub max_htlc_value_in_flight_msat: u64, // this exceeds what fits into u64
-    pub their_channel_reserve_satoshis: u64,
-    pub our_channel_reserve_satoshis: u64,
-    pub spendable_msatoshi: u64,
-    pub htlc_minimum_msat: u64,
+    pub close_to_addr: Option<String>,
+    pub close_to: Option<String>,
+    pub private: bool,
+    pub funding_msat: HashMap<String, MSat>,
+    pub to_us_msat: MSat,
+    pub min_to_us_msat: MSat,
+    pub max_to_us_msat: MSat,
+    pub total_msat: MSat,
+    pub dust_limit_msat: MSat,
+    pub max_total_htlc_in_msat: MSat, // this exceeds what fits into u64
+    pub their_reserve_msat: MSat,
+    pub our_reserve_msat: MSat,
+    pub spendable_msat: MSat,
+    pub receivable_msat: MSat,
+    pub minimum_htlc_in_msat: MSat,
     pub their_to_self_delay: u64,
     pub our_to_self_delay: u64,
     pub max_accepted_htlcs: u64,
     pub status: Vec<String>,
     pub in_payments_offered: u64,
-    pub in_msatoshi_offered: u64,
+    pub in_offered_msat: MSat,
     pub in_payments_fulfilled: u64,
-    pub in_msatoshi_fulfilled: u64,
+    pub in_fulfilled_msat: MSat,
     pub out_payments_offered: u64,
-    pub out_msatoshi_offered: u64,
+    pub out_offered_msat: MSat,
     pub out_payments_fulfilled: u64,
-    pub out_msatoshi_fulfilled: u64,
-}
-
-/// Sub-structure for log entry in 'listpeers'
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Log {
-    #[serde(rename = "type")]
-    pub type_: String,
-    pub time: String,
-    pub source: String,
-    pub log: String,
+    pub out_fulfilled_msat: MSat,
+    pub htlcs: Vec<Htlc>,
 }
 
 /// Sub-structure for peer in 'listpeers'
@@ -203,10 +239,9 @@ pub struct Peer {
     pub id: String,
     pub connected: bool,
     pub netaddr: Option<Vec<String>>,
-    pub local_features: Option<String>,
-    pub global_features: Option<String>,
+    pub features: Option<String>,
     pub channels: Vec<Channel>,
-    pub log: Option<Vec<Log>>,
+    pub log: Option<Vec<LogEntry>>,
 }
 
 /// 'listpeers' command
@@ -221,11 +256,14 @@ pub struct ListInvoice {
     pub label: String,
     pub bolt11: String,
     pub payment_hash: String,
-    pub msatoshi: u64,
+    pub amount_msat: Option<MSat>,
     pub status: String,
-    pub expires_at: u64,
     pub pay_index: Option<u64>,
+    pub amount_received_msat: Option<MSat>,
     pub paid_at: Option<u64>,
+    pub payment_preimage: Option<String>,
+    pub description: Option<String>,
+    pub expires_at: u64,
 }
 
 /// 'listinvoices' command
@@ -298,36 +336,77 @@ pub struct SendPay {
 
     pub id: u64,
     pub payment_hash: String,
-    pub destination: String,
-    pub msatoshi: u64,
-    pub msatoshi_sent: u64,
+    pub partid: Option<u64>,
+    pub destination: Option<String>,
+    pub amount_msat: Option<MSat>,
+    pub amount_sent_msat: MSat,
     pub created_at: u64,
     pub status: String,
     pub payment_preimage: Option<String>,
     pub description: Option<String>,
+    pub bolt11: Option<String>,
+    pub erroronion: Option<String>,
+
+    pub onionreply: Option<String>,
+    pub erring_index: Option<u64>,
+    pub failcode: Option<u64>,
+    pub failcodename: Option<String>,
+    pub erring_node: Option<String>,
+    pub erring_channel: Option<String>,
+    pub erring_direction: Option<u64>,
+    pub raw_message: Option<String>,
 }
 
-/// Sub-structure for payments in 'listpayments' and 'waitsendpay'
+/// Sub-structure for payments in 'listsendpays' and 'waitsendpay'
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListPaymentsItem {
+pub struct ListSendPaysItem {
     pub id: u64,
     pub payment_hash: String,
-    pub destination: String,
-    pub msatoshi: u64,
-    pub msatoshi_sent: u64,
+    pub partid: Option<u64>,
+    pub destination: Option<String>,
+    pub amount_msat: Option<MSat>,
+    pub amount_sent_msat: MSat,
     pub created_at: u64,
     pub status: String,
     pub payment_preimage: Option<String>,
     pub description: Option<String>,
+    pub bolt11: Option<String>,
+    pub erroronion: Option<String>,
 }
 
 /// 'waitsendpay' command
-pub type WaitSendPay = ListPaymentsItem;
+pub type WaitSendPay = ListSendPaysItem;
 
-/// 'listpayments' command
+/// 'listsendpays' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListPayments {
-    pub payments: Vec<ListPaymentsItem>,
+pub struct ListSendPays {
+    pub payments: Vec<ListSendPaysItem>,
+}
+
+/// Sub-structure for fallbacks in 'decodepay'
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Fallback {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub addr: String,
+    pub hex: String,
+}
+
+/// Sub-structure for routes in 'decodepay'
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DecodePayRoute {
+    pub pubkey: String,
+    pub short_channel_id: String,
+    pub fee_base_msat: u64,
+    pub fee_proportional_millionths: u64,
+    pub cltv_expiry_delta: u64,
+}
+
+/// Sub-structure for extra in 'decodepay'
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Extra {
+    pub tag: String,
+    pub data: String,
 }
 
 /// 'decodepay' command
@@ -337,9 +416,15 @@ pub struct DecodePay {
     pub created_at: u64,
     pub expiry: u64,
     pub payee: String,
-    pub msatoshi: u64,
-    pub description: String,
+    pub amount_msat: Option<MSat>,
+    pub description: Option<String>,
+    pub description_hash: Option<String>,
     pub min_final_cltv_expiry: u64,
+    pub payment_secret: Option<String>,
+    pub features: Option<String>,
+    pub fallbacks: Option<Vec<Fallback>>,
+    pub routes: Option<Vec<Vec<DecodePayRoute>>>,
+    pub extra: Option<Vec<Extra>>,
     pub payment_hash: String,
     pub signature: String,
 }
@@ -354,6 +439,7 @@ pub struct GetRoute {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Connect {
     pub id: String,
+    pub features: String,
 }
 
 /// 'disconnect' command
@@ -388,7 +474,7 @@ pub struct Ping {
 pub struct ListFundsOutput {
     pub txid: String,
     pub output: u64,
-    pub value: u64,
+    pub amount_msat: MSat,
     pub address: String,
     pub status: String,
 }
@@ -397,10 +483,12 @@ pub struct ListFundsOutput {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ListFundsChannel {
     pub peer_id: String,
+    pub connected: bool,
     pub short_channel_id: Option<String>,
-    pub channel_sat: u64,
-    pub channel_total_sat: u64,
+    pub our_amount_msat: MSat,
+    pub amount_msat: MSat,
     pub funding_txid: String,
+    pub funding_output: u64,
 }
 
 /// 'listfunds' command
@@ -420,7 +508,10 @@ pub struct Withdraw {
 /// 'newaddr' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NewAddr {
-    pub address: String,
+    pub address: Option<String>,
+    pub bech32: Option<String>,
+    #[serde(rename = "p2sh-segwit")]
+    pub p2sh_segwit: Option<String>,
 }
 
 /// 'stop' command


### PR DESCRIPTION
Hi! I'm writing [Prometheus exporter for c-lightning](https://github.com/mmilata/prometheus-clightning-exporter) where async API (#1) for talking to c-lightning would be useful.

This PR proposes an approach that doesn't depend on any particular runtime, just on the `futures` crate. User of the library is responsible for opening the unix socket, then they can pass the handle to `lightningrpc::aio::LightningRpc` which works with anything that implements [AsyncRead](https://docs.rs/futures/0.3/futures/prelude/trait.AsyncRead.html) and [AsyncWrite](https://docs.rs/futures/0.3/futures/prelude/trait.AsyncWrite.html), such as [tokio::net::UnixStream](https://docs.rs/tokio/0.2/tokio/net/struct.UnixStream.html) or [async_std::os::unix::net::UnixStream](https://docs.rs/async-std/1.6/async_std/os/unix/net/struct.UnixStream.html).

Disadvantages:
* Because the library can't open the socket I couldn't think of a way to refactor the blocking API to use the async API so the high-level interfaces are duplicated. Perhaps this can be solved with macros.
* There doesn't seem to be an obvious way to parse JSONs incrementally so the responses are read into buffer before deserializing. The implementation relies on the responses being split by newlines which e.g. the python client shipped in the c-lightning repo also does.
* RPC struct must be `mut` in order to call methods on it.

What do you think? Does it make sense to include this kind of API?

(edit: depends on #19)