### PR TITLE
Update parts of the interface for c-lightning 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/laanwj/rust-clightning-rpc.git"
 description = "Crate that provides an RPC binding from rust code to the c-lightning daemon"
 keywords = [ "protocol", "rpc", "lightning", "bitcoin" ]
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 serde = "1"

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ use serde::de::DeserializeOwned;
 use serde_json::{Deserializer, to_writer};
 
 use super::{Request, Response};
-use error::Error;
+use crate::error::Error;
 
 /// A handle to a remote JSONRPC server
 #[derive(Debug)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,10 @@
 #![allow(missing_docs)]
 //! Common structures between requests and responses
 
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+
 /// Sub-structure for route in 'pay', 'getroute' and 'sendpay'
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RouteItem {
@@ -8,4 +12,64 @@ pub struct RouteItem {
     pub channel: String,
     pub msatoshi: i64,
     pub delay: i64,
+}
+
+/// Type-safe millisatoshi wrapper
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MSat(pub u64);
+
+impl Serialize for MSat {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}msat", self.0))
+    }
+}
+
+struct MSatVisitor;
+
+impl<'d> de::Visitor<'d> for MSatVisitor {
+    type Value = MSat;
+
+    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        if !s.ends_with("msat") {
+            return Err(E::custom("missing msat suffix"));
+        }
+
+        let numpart = s
+            .get(0..(s.len() - 4))
+            .ok_or_else(|| E::custom("missing msat suffix"))?;
+
+        let res = u64::from_str(numpart).map_err(|_| E::custom("not a number"))?;
+        Ok(MSat(res))
+    }
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a string ending with \"msat\"")
+    }
+}
+
+impl<'d> Deserialize<'d> for MSat {
+    fn deserialize<D>(deserializer: D) -> Result<MSat, D::Error>
+    where
+        D: Deserializer<'d>,
+    {
+        deserializer.deserialize_str(MSatVisitor)
+    }
+}
+
+impl fmt::Debug for MSat {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}msat", self.0)
+    }
+}
+
+impl fmt::Display for MSat {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}msat", self.0)
+    }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,8 +10,12 @@ use std::str::FromStr;
 pub struct RouteItem {
     pub id: String,
     pub channel: String,
-    pub msatoshi: i64,
+    pub direction: Option<u64>,
+    pub amount_msat: MSat,
     pub delay: i64,
+    pub style: Option<String>,
+    pub blinding: Option<String>,
+    pub enctlv: Option<String>,
 }
 
 /// Type-safe millisatoshi wrapper

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,9 @@ pub mod requests;
 pub mod responses;
 
 // Re-export error type
-pub use error::Error;
+pub use crate::error::Error;
 // Re-export high-level connection type
-pub use lightningrpc::LightningRPC;
+pub use crate::lightningrpc::LightningRPC;
 
 use serde::Serialize;
 

--- a/src/lightningrpc.rs
+++ b/src/lightningrpc.rs
@@ -253,14 +253,14 @@ impl LightningRPC {
     }
 
     /// Show outgoing payments.
-    pub fn listpayments(
+    pub fn listsendpays(
         &self,
         bolt11: Option<&str>,
         payment_hash: Option<&str>,
-    ) -> Result<responses::ListPayments, Error> {
+    ) -> Result<responses::ListSendPays, Error> {
         self.call(
-            "listpayments",
-            requests::ListPayments {
+            "listsendpays",
+            requests::ListSendPays {
                 bolt11,
                 payment_hash,
             },

--- a/src/lightningrpc.rs
+++ b/src/lightningrpc.rs
@@ -4,11 +4,11 @@ use std::path::Path;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use client;
-use common;
-use error::Error;
-use requests;
-use responses;
+use crate::client;
+use crate::common;
+use crate::error::Error;
+use crate::requests;
+use crate::responses;
 
 /// Structure providing a high-level interface to the c-lightning daemon RPC
 #[derive(Debug)]

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -163,9 +163,9 @@ pub struct WaitSendPay<'a> {
     pub timeout: u64,
 }
 
-/// 'listpayments' command
+/// 'listsendpays' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListPayments<'a> {
+pub struct ListSendPays<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bolt11: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -16,7 +16,7 @@
 #![allow(missing_docs)]
 use serde::{Serialize, Serializer};
 
-use common;
+use crate::common;
 
 /// 'getinfo' command
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -18,7 +18,7 @@ use serde_json;
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use common;
+use crate::common;
 
 /// structure for network addresses
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::common;
+use crate::common::MSat;
 
 /// structure for network addresses
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -48,18 +49,33 @@ pub struct GetInfo {
     pub id: String,
     pub alias: String,
     pub color: String,
+    pub num_peers: u64,
+    pub num_pending_channels: u64,
+    pub num_active_channels: u64,
+    pub num_inactive_channels: u64,
     pub address: Vec<NetworkAddress>,
     pub binding: Vec<NetworkAddress>,
     pub version: String,
     pub blockheight: u64,
+    pub fees_collected_msat: MSat,
     pub network: String,
+    #[serde(rename = "lightning-dir")]
+    pub ligthning_dir: String,
+    pub warning_bitcoind_sync: Option<String>,
+    pub warning_lightningd_sync: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FeeRatesInner {
-    pub urgent: u64,
-    pub normal: u64,
-    pub slow: u64,
+    pub urgent: Option<u64>,
+    pub normal: Option<u64>,
+    pub slow: Option<u64>,
+    pub opening: u64,
+    pub mutual_close: u64,
+    pub unilateral_close: u64,
+    pub delayed_to_us: u64,
+    pub htlc_resolution: u64,
+    pub penalty: u64,
     pub min_acceptable: u64,
     pub max_acceptable: u64,
 }
@@ -69,6 +85,8 @@ pub struct FeeRatesOnchain {
     pub opening_channel_satoshis: u64,
     pub mutual_close_satoshis: u64,
     pub unilateral_close_satoshis: u64,
+    pub htlc_timeout_satoshis: u64,
+    pub htlc_success_satoshis: u64,
 }
 
 /// 'feerates' command
@@ -76,6 +94,7 @@ pub struct FeeRatesOnchain {
 pub struct FeeRates {
     pub perkb: Option<FeeRatesInner>,
     pub perkw: Option<FeeRatesInner>,
+    pub warning: Option<String>,
     pub onchain_fee_estimates: Option<FeeRatesOnchain>,
 }
 
@@ -86,7 +105,7 @@ pub struct ListNodesItem {
     pub alias: Option<String>,
     pub color: Option<String>,
     pub last_timestamp: Option<u64>,
-    pub global_features: Option<String>,
+    pub features: Option<String>,
     pub addresses: Option<Vec<NetworkAddress>>,
 }
 
@@ -103,13 +122,17 @@ pub struct ListChannelsItem {
     pub destination: String,
     pub short_channel_id: String,
     pub public: bool,
-    pub satoshis: u64,
-    pub flags: u64,
+    pub amount_msat: MSat,
+    pub message_flags: u64,
+    pub channel_flags: u64,
     pub active: bool,
     pub last_update: u64,
     pub base_fee_millisatoshi: u64,
     pub fee_per_millionth: u64,
     pub delay: u64,
+    pub htlc_minimum_msat: MSat,
+    pub htlc_maximum_msat: MSat,
+    pub features: String,
 }
 
 /// 'listchannels' command
@@ -122,25 +145,28 @@ pub struct ListChannels {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HelpItem {
     pub command: String,
+    pub category: String,
     pub description: String,
+    pub verbose: String,
 }
 
 /// 'help' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Help {
     pub help: Option<Vec<HelpItem>>,
-    pub verbose: Option<String>,
 }
 
-/// Sub-structure for 'getlog' item
+/// Sub-structure for 'getlog' and 'listpeers' item
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LogEntry {
     #[serde(rename = "type")]
     pub type_: String,
     pub num_skipped: Option<u64>,
     pub time: Option<String>,
+    pub node_id: Option<String>,
     pub source: Option<String>,
     pub log: Option<String>,
+    pub data: Option<String>,
 }
 
 /// 'getlog' command
@@ -155,46 +181,56 @@ pub struct GetLog {
 /// 'listconfigs' command
 pub type ListConfigs = HashMap<String, serde_json::Value>;
 
+/// Sub-structure for htlcs in 'listpeers'
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Htlc {
+    pub direction: String,
+    pub id: u64,
+    pub amount_msat: MSat,
+    pub expiry: u64,
+    pub payment_hash: String,
+    pub state: String,
+    pub local_trimmed: Option<bool>,
+}
+
 /// Sub-structure for channel in 'listpeers'
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Channel {
     pub state: String,
+    pub scratch_txid: Option<String>,
     pub owner: Option<String>,
     pub short_channel_id: Option<String>,
+    pub direction: Option<u64>,
     pub channel_id: String,
     pub funding_txid: String,
-    pub msatoshi_to_us: u64,
-    pub msatoshi_to_us_min: u64,
-    pub msatoshi_to_us_max: u64,
-    pub msatoshi_total: u64,
-    pub dust_limit_satoshis: u64,
-    pub max_htlc_value_in_flight_msat: u64, // this exceeds what fits into u64
-    pub their_channel_reserve_satoshis: u64,
-    pub our_channel_reserve_satoshis: u64,
-    pub spendable_msatoshi: u64,
-    pub htlc_minimum_msat: u64,
+    pub close_to_addr: Option<String>,
+    pub close_to: Option<String>,
+    pub private: bool,
+    pub funding_msat: HashMap<String, MSat>,
+    pub to_us_msat: MSat,
+    pub min_to_us_msat: MSat,
+    pub max_to_us_msat: MSat,
+    pub total_msat: MSat,
+    pub dust_limit_msat: MSat,
+    pub max_total_htlc_in_msat: MSat, // this exceeds what fits into u64
+    pub their_reserve_msat: MSat,
+    pub our_reserve_msat: MSat,
+    pub spendable_msat: MSat,
+    pub receivable_msat: MSat,
+    pub minimum_htlc_in_msat: MSat,
     pub their_to_self_delay: u64,
     pub our_to_self_delay: u64,
     pub max_accepted_htlcs: u64,
     pub status: Vec<String>,
     pub in_payments_offered: u64,
-    pub in_msatoshi_offered: u64,
+    pub in_offered_msat: MSat,
     pub in_payments_fulfilled: u64,
-    pub in_msatoshi_fulfilled: u64,
+    pub in_fulfilled_msat: MSat,
     pub out_payments_offered: u64,
-    pub out_msatoshi_offered: u64,
+    pub out_offered_msat: MSat,
     pub out_payments_fulfilled: u64,
-    pub out_msatoshi_fulfilled: u64,
-}
-
-/// Sub-structure for log entry in 'listpeers'
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Log {
-    #[serde(rename = "type")]
-    pub type_: String,
-    pub time: String,
-    pub source: String,
-    pub log: String,
+    pub out_fulfilled_msat: MSat,
+    pub htlcs: Vec<Htlc>,
 }
 
 /// Sub-structure for peer in 'listpeers'
@@ -203,10 +239,9 @@ pub struct Peer {
     pub id: String,
     pub connected: bool,
     pub netaddr: Option<Vec<String>>,
-    pub local_features: Option<String>,
-    pub global_features: Option<String>,
+    pub features: Option<String>,
     pub channels: Vec<Channel>,
-    pub log: Option<Vec<Log>>,
+    pub log: Option<Vec<LogEntry>>,
 }
 
 /// 'listpeers' command
@@ -221,11 +256,14 @@ pub struct ListInvoice {
     pub label: String,
     pub bolt11: String,
     pub payment_hash: String,
-    pub msatoshi: u64,
+    pub amount_msat: Option<MSat>,
     pub status: String,
-    pub expires_at: u64,
     pub pay_index: Option<u64>,
+    pub amount_received_msat: Option<MSat>,
     pub paid_at: Option<u64>,
+    pub payment_preimage: Option<String>,
+    pub description: Option<String>,
+    pub expires_at: u64,
 }
 
 /// 'listinvoices' command
@@ -298,36 +336,77 @@ pub struct SendPay {
 
     pub id: u64,
     pub payment_hash: String,
-    pub destination: String,
-    pub msatoshi: u64,
-    pub msatoshi_sent: u64,
+    pub partid: Option<u64>,
+    pub destination: Option<String>,
+    pub amount_msat: Option<MSat>,
+    pub amount_sent_msat: MSat,
     pub created_at: u64,
     pub status: String,
     pub payment_preimage: Option<String>,
     pub description: Option<String>,
+    pub bolt11: Option<String>,
+    pub erroronion: Option<String>,
+
+    pub onionreply: Option<String>,
+    pub erring_index: Option<u64>,
+    pub failcode: Option<u64>,
+    pub failcodename: Option<String>,
+    pub erring_node: Option<String>,
+    pub erring_channel: Option<String>,
+    pub erring_direction: Option<u64>,
+    pub raw_message: Option<String>,
 }
 
-/// Sub-structure for payments in 'listpayments' and 'waitsendpay'
+/// Sub-structure for payments in 'listsendpays' and 'waitsendpay'
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListPaymentsItem {
+pub struct ListSendPaysItem {
     pub id: u64,
     pub payment_hash: String,
-    pub destination: String,
-    pub msatoshi: u64,
-    pub msatoshi_sent: u64,
+    pub partid: Option<u64>,
+    pub destination: Option<String>,
+    pub amount_msat: Option<MSat>,
+    pub amount_sent_msat: MSat,
     pub created_at: u64,
     pub status: String,
     pub payment_preimage: Option<String>,
     pub description: Option<String>,
+    pub bolt11: Option<String>,
+    pub erroronion: Option<String>,
 }
 
 /// 'waitsendpay' command
-pub type WaitSendPay = ListPaymentsItem;
+pub type WaitSendPay = ListSendPaysItem;
 
-/// 'listpayments' command
+/// 'listsendpays' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListPayments {
-    pub payments: Vec<ListPaymentsItem>,
+pub struct ListSendPays {
+    pub payments: Vec<ListSendPaysItem>,
+}
+
+/// Sub-structure for fallbacks in 'decodepay'
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Fallback {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub addr: String,
+    pub hex: String,
+}
+
+/// Sub-structure for routes in 'decodepay'
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DecodePayRoute {
+    pub pubkey: String,
+    pub short_channel_id: String,
+    pub fee_base_msat: u64,
+    pub fee_proportional_millionths: u64,
+    pub cltv_expiry_delta: u64,
+}
+
+/// Sub-structure for extra in 'decodepay'
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Extra {
+    pub tag: String,
+    pub data: String,
 }
 
 /// 'decodepay' command
@@ -337,9 +416,15 @@ pub struct DecodePay {
     pub created_at: u64,
     pub expiry: u64,
     pub payee: String,
-    pub msatoshi: u64,
-    pub description: String,
+    pub amount_msat: Option<MSat>,
+    pub description: Option<String>,
+    pub description_hash: Option<String>,
     pub min_final_cltv_expiry: u64,
+    pub payment_secret: Option<String>,
+    pub features: Option<String>,
+    pub fallbacks: Option<Vec<Fallback>>,
+    pub routes: Option<Vec<Vec<DecodePayRoute>>>,
+    pub extra: Option<Vec<Extra>>,
     pub payment_hash: String,
     pub signature: String,
 }
@@ -354,6 +439,7 @@ pub struct GetRoute {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Connect {
     pub id: String,
+    pub features: String,
 }
 
 /// 'disconnect' command
@@ -388,7 +474,7 @@ pub struct Ping {
 pub struct ListFundsOutput {
     pub txid: String,
     pub output: u64,
-    pub value: u64,
+    pub amount_msat: MSat,
     pub address: String,
     pub status: String,
 }
@@ -397,10 +483,12 @@ pub struct ListFundsOutput {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ListFundsChannel {
     pub peer_id: String,
+    pub connected: bool,
     pub short_channel_id: Option<String>,
-    pub channel_sat: u64,
-    pub channel_total_sat: u64,
+    pub our_amount_msat: MSat,
+    pub amount_msat: MSat,
     pub funding_txid: String,
+    pub funding_output: u64,
 }
 
 /// 'listfunds' command
@@ -420,7 +508,10 @@ pub struct Withdraw {
 /// 'newaddr' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NewAddr {
-    pub address: String,
+    pub address: Option<String>,
+    pub bech32: Option<String>,
+    #[serde(rename = "p2sh-segwit")]
+    pub p2sh_segwit: Option<String>,
 }
 
 /// 'stop' command


### PR DESCRIPTION
This does not cover the 0.8 API completely, notably:
* the `pay` method remains to be updated,
* there is number of new methods not addressed in this PR.

Perhaps it can still be useful for monitoring use-cases, or someone else can use pick up this PR to make complete update.

Since c-lightning 0.7 amounts are represented as strings with `msat` suffix. Although there are usually corresponding numeric fields, my understanding is that the string representation is preferred and therefore is used in this PR. Such amounts are wrapped in `MSat` newtype.