### PR TITLE
init the plugin crater with a minimal implementation of it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Cargo.lock
 **/*.info
 
 github-merge.py
+
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
         "rpc",
         "common",
+        "plugin",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ members = [
         "common",
         "plugin",
 ]
+resolver = "2"
+

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ fmt:
 
 check:
 	$(CC) test --all
+
+clean:
+	$(CC) clean

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::{Error, RpcError};
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 /// A JSONRPC request object
 pub struct Request<'f, T: Serialize> {
     /// The name of the RPC call

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "clightningrpc-plugin"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clightningrpc-common = { path = "../common" }

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -3,7 +3,8 @@ name = "clightningrpc-plugin"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 clightningrpc-common = { path = "../common" }
+clightningrpc = { path = "../rpc", optional = true }

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "clightningrpc-plugin"
+name = "clightningrpc_plugin"
 version = "0.1.0"
 edition = "2021"
 

--- a/plugin/examples/foo_plugin.rs
+++ b/plugin/examples/foo_plugin.rs
@@ -1,6 +1,6 @@
 extern crate clightningrpc_plugin;
 
-use clightningrpc_plugin::{commands::RPCMethod, plugin::Plugin};
+use clightningrpc_plugin::{commands::RPCCommand, plugin::Plugin};
 use serde_json::{json, Value};
 
 #[derive(Clone)]
@@ -9,7 +9,7 @@ struct PluginState(());
 #[derive(Clone)]
 struct HelloRPC {}
 
-impl RPCMethod<PluginState> for HelloRPC {
+impl RPCCommand<PluginState> for HelloRPC {
     fn call<'c>(&self, _plugin: &mut Plugin<PluginState>, _request: &'c Value) -> Value {
         json!({
             "language": "Hello from rust"

--- a/plugin/examples/foo_plugin.rs
+++ b/plugin/examples/foo_plugin.rs
@@ -10,7 +10,7 @@ struct PluginState(());
 struct HelloRPC {}
 
 impl RPCMethod<PluginState> for HelloRPC {
-    fn call<'c>(&self, plugin: &mut Plugin<PluginState>, request: &'c Value) -> Value {
+    fn call<'c>(&self, _plugin: &mut Plugin<PluginState>, _request: &'c Value) -> Value {
         json!({
             "language": "Hello from rust"
         })

--- a/plugin/examples/foo_plugin.rs
+++ b/plugin/examples/foo_plugin.rs
@@ -1,0 +1,37 @@
+extern crate clightningrpc_plugin;
+
+use clightningrpc_plugin::{commands::RPCMethod, plugin::Plugin};
+use serde_json::{json, Value};
+
+#[derive(Clone)]
+struct PluginState(());
+
+#[derive(Clone)]
+struct HelloRPC {}
+
+impl RPCMethod<PluginState> for HelloRPC {
+    fn call<'c>(&self, plugin: &mut Plugin<PluginState>, request: &'c Value) -> Value {
+        json!({
+            "language": "Hello from rust"
+        })
+    }
+}
+
+fn main() {
+    let mut plugin = Plugin::<PluginState>::new(PluginState(()), true)
+        .add_rpc_method(
+            "hello",
+            "",
+            "show how is possible add a method",
+            HelloRPC {},
+        )
+        .add_opt(
+            "foo",
+            "flag",
+            None,
+            "An example of command line option",
+            false,
+        )
+        .clone();
+    plugin.start();
+}

--- a/plugin/src/commands/builtin.rs
+++ b/plugin/src/commands/builtin.rs
@@ -4,7 +4,7 @@
 //! author: https://github.com/vincenzopalazzo
 use crate::commands::{
     types::{InitConf, RPCHookInfo, RPCMethodInfo},
-    RPCMethod,
+    RPCCommand,
 };
 // FIXME: move this inside the common crater
 use crate::commands::json_utils::{add_bool, add_vec, init_payload};
@@ -15,7 +15,7 @@ use serde_json::Value;
 #[derive(Clone)]
 pub struct ManifestRPC {}
 
-impl<T: Clone> RPCMethod<T> for ManifestRPC {
+impl<T: Clone> RPCCommand<T> for ManifestRPC {
     fn call<'c>(&self, plugin: &mut Plugin<T>, _request: &'c Value) -> Value {
         let mut response = init_payload();
         add_vec::<RpcOption>(
@@ -47,7 +47,7 @@ impl<T: Clone> RPCMethod<T> for ManifestRPC {
 #[derive(Clone)]
 pub struct InitRPC {}
 
-impl<T: Clone> RPCMethod<T> for InitRPC {
+impl<T: Clone> RPCCommand<T> for InitRPC {
     fn call<'c>(&self, _plugin: &mut Plugin<T>, request: &'c Value) -> Value {
         let response = init_payload();
         let _conf: InitConf = serde_json::from_value(request.to_owned()).unwrap();

--- a/plugin/src/commands/builtin.rs
+++ b/plugin/src/commands/builtin.rs
@@ -1,0 +1,48 @@
+//! RPC method built inside the plugin that are required
+//! by core lightning in other to configure the plugin at startup.
+//!
+//! author: https://github.com/vincenzopalazzo
+use crate::commands::{
+    types::{InitConf, RPCMethodInfo},
+    RPCMethod,
+};
+// FIXME: move this inside the common crater
+use crate::commands::json_utils::{add_bool, add_vec, init_payload};
+use crate::plugin::Plugin;
+use crate::types::RpcOption;
+use serde_json::Value;
+
+#[derive(Clone)]
+pub struct ManifestRPC {}
+
+impl<T: Clone> RPCMethod<T> for ManifestRPC {
+    fn call<'c>(&self, plugin: &mut Plugin<T>, _request: &'c Value) -> Value {
+        let mut response = init_payload();
+        add_vec::<RpcOption>(
+            &mut response,
+            "options",
+            plugin.option.clone().into_iter().collect(),
+        );
+        add_vec::<RPCMethodInfo>(
+            &mut response,
+            "rpcmethods",
+            plugin.rpc_info.clone().into_iter().collect(),
+        );
+        // TODO: fill later
+        add_vec::<String>(&mut response, "subscriptions", vec![]);
+        add_vec::<String>(&mut response, "hooks", vec![]);
+        add_bool(&mut response, "dynamic", plugin.dynamic);
+        response
+    }
+}
+
+#[derive(Clone)]
+pub struct InitRPC {}
+
+impl<T: Clone> RPCMethod<T> for InitRPC {
+    fn call<'c>(&self, _plugin: &mut Plugin<T>, request: &'c Value) -> Value {
+        let response = init_payload();
+        let _conf: InitConf = serde_json::from_value(request.to_owned()).unwrap();
+        response
+    }
+}

--- a/plugin/src/commands/builtin.rs
+++ b/plugin/src/commands/builtin.rs
@@ -3,7 +3,7 @@
 //!
 //! author: https://github.com/vincenzopalazzo
 use crate::commands::{
-    types::{InitConf, RPCMethodInfo},
+    types::{InitConf, RPCHookInfo, RPCMethodInfo},
     RPCMethod,
 };
 // FIXME: move this inside the common crater
@@ -28,9 +28,17 @@ impl<T: Clone> RPCMethod<T> for ManifestRPC {
             "rpcmethods",
             plugin.rpc_info.clone().into_iter().collect(),
         );
-        // TODO: fill later
-        add_vec::<String>(&mut response, "subscriptions", vec![]);
-        add_vec::<String>(&mut response, "hooks", vec![]);
+        add_vec::<String>(
+            &mut response,
+            "subscriptions",
+            plugin.rpc_nofitication.keys().cloned().collect(),
+        );
+        add_vec::<RPCHookInfo>(
+            &mut response,
+            "hooks",
+            plugin.hook_info.clone().into_iter().collect(),
+        );
+        // FIXME: adding possibility to register a plugin notification
         add_bool(&mut response, "dynamic", plugin.dynamic);
         response
     }

--- a/plugin/src/commands/json_utils.rs
+++ b/plugin/src/commands/json_utils.rs
@@ -1,0 +1,28 @@
+use serde::Serialize;
+use serde_json::{json, Number};
+
+pub fn init_payload() -> serde_json::Value {
+    json!({})
+}
+
+pub fn init_success_response(id: u64) -> serde_json::Value {
+    json!(
+        {
+            "id": id,
+            "jsonrpc": "2.0",
+        }
+    )
+}
+
+pub fn add_number(payload: &mut serde_json::Value, key: &str, value: i64) {
+    payload[key.to_string()] = serde_json::Value::Number(Number::from(value));
+}
+
+pub fn add_bool(payload: &mut serde_json::Value, key: &str, value: bool) {
+    payload[key.to_string()] = serde_json::Value::Bool(value);
+}
+
+pub fn add_vec<V: Serialize>(payload: &mut serde_json::Value, key: &str, value: Vec<V>) {
+    let vec = json!(value);
+    payload[key.to_string()] = serde_json::Value::Array(vec.as_array().unwrap().clone());
+}

--- a/plugin/src/commands/json_utils.rs
+++ b/plugin/src/commands/json_utils.rs
@@ -18,6 +18,10 @@ pub fn add_number(payload: &mut serde_json::Value, key: &str, value: i64) {
     payload[key.to_string()] = serde_json::Value::Number(Number::from(value));
 }
 
+pub fn add_str(payload: &mut serde_json::Value, key: &str, value: &str) {
+    payload[key.to_owned()] = serde_json::Value::String(value.to_owned());
+}
+
 pub fn add_bool(payload: &mut serde_json::Value, key: &str, value: bool) {
     payload[key.to_string()] = serde_json::Value::Bool(value);
 }

--- a/plugin/src/commands/mod.rs
+++ b/plugin/src/commands/mod.rs
@@ -9,34 +9,39 @@ use serde_json;
 
 use super::plugin::Plugin;
 
-pub trait RPCMethod<T: Clone>: RPCMethodClone<T> {
+/// RPCCommand is a implementation of the callback using the command pattern.
+///
+/// The usage of the pattern is a design choice to avoid to define a callback type
+/// in contrast, it is more complex but the plugin_macros package will help to simplify the API.
+pub trait RPCCommand<T: Clone>: RPCCommandClone<T> {
+    /// call is a generic method that it is used to simulate the callback.
     fn call<'c>(&self, plugin: &mut Plugin<T>, request: &'c serde_json::Value)
         -> serde_json::Value;
 }
 
-// Splitting RPCMethodClone into its own trait allows us to provide a blanket
+// Splitting RPCCommandClone into its own trait allows us to provide a blanket
 // implementation for all compatible types, without having to implement the
-// rest of RPCMethod. In this case, we implement it for all types that have
+// rest of RPCCommand. In this case, we implement it for all types that have
 // 'static lifetime (*i.e.* they don't contain non-'static pointers), and
-// implement both RPCMethod and Clone.  Don't ask me how the compiler resolves
-// implementing RPCMethodClone for dyn Animal when RPCMethod requires RPCMethodClone;
+// implement both RPCCommand and Clone.  Don't ask me how the compiler resolves
+// implementing RPCCommandClone for dyn Animal when RPCCommand requires RPCCommandClone;
 // I have *no* idea why this works.
-pub trait RPCMethodClone<T: Clone> {
-    fn clone_box(&self) -> Box<dyn RPCMethod<T>>;
+pub trait RPCCommandClone<T: Clone> {
+    fn clone_box(&self) -> Box<dyn RPCCommand<T>>;
 }
 
-impl<'a, F, T: Clone> RPCMethodClone<T> for F
+impl<'a, F, T: Clone> RPCCommandClone<T> for F
 where
-    F: 'static + RPCMethod<T> + Clone,
+    F: 'static + RPCCommand<T> + Clone,
 {
-    fn clone_box(&self) -> Box<dyn RPCMethod<T>> {
+    fn clone_box(&self) -> Box<dyn RPCCommand<T>> {
         Box::new(self.clone())
     }
 }
 
 // We can now implement Clone manually by forwarding to clone_box.
-impl<T: Clone> Clone for Box<dyn RPCMethod<T>> {
-    fn clone(&self) -> Box<dyn RPCMethod<T>> {
+impl<T: Clone> Clone for Box<dyn RPCCommand<T>> {
+    fn clone(&self) -> Box<dyn RPCCommand<T>> {
         self.clone_box()
     }
 }

--- a/plugin/src/commands/mod.rs
+++ b/plugin/src/commands/mod.rs
@@ -1,0 +1,42 @@
+//!
+//!
+//! author: https://github.com/vincenzopalazzo
+pub mod builtin;
+pub mod json_utils;
+pub mod types;
+
+use serde_json;
+
+use super::plugin::Plugin;
+
+pub trait RPCMethod<T: Clone>: RPCMethodClone<T> {
+    fn call<'c>(&self, plugin: &mut Plugin<T>, request: &'c serde_json::Value)
+        -> serde_json::Value;
+}
+
+// Splitting RPCMethodClone into its own trait allows us to provide a blanket
+// implementation for all compatible types, without having to implement the
+// rest of RPCMethod. In this case, we implement it for all types that have
+// 'static lifetime (*i.e.* they don't contain non-'static pointers), and
+// implement both RPCMethod and Clone.  Don't ask me how the compiler resolves
+// implementing RPCMethodClone for dyn Animal when RPCMethod requires RPCMethodClone;
+// I have *no* idea why this works.
+pub trait RPCMethodClone<T: Clone> {
+    fn clone_box(&self) -> Box<dyn RPCMethod<T>>;
+}
+
+impl<'a, F, T: Clone> RPCMethodClone<T> for F
+where
+    F: 'static + RPCMethod<T> + Clone,
+{
+    fn clone_box(&self) -> Box<dyn RPCMethod<T>> {
+        Box::new(self.clone())
+    }
+}
+
+// We can now implement Clone manually by forwarding to clone_box.
+impl<T: Clone> Clone for Box<dyn RPCMethod<T>> {
+    fn clone(&self) -> Box<dyn RPCMethod<T>> {
+        self.clone_box()
+    }
+}

--- a/plugin/src/commands/types.rs
+++ b/plugin/src/commands/types.rs
@@ -1,0 +1,44 @@
+//! command types contains all the type that are important
+//! to implement the plugin library.
+//!
+//! author: https://github.com/vincenzopalazzo
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Clone, Eq, Hash, PartialEq, Serialize)]
+pub struct RPCMethodInfo {
+    pub name: String,
+    pub usage: String,
+    pub description: String,
+    pub long_description: String,
+    pub deprecated: bool,
+}
+
+#[derive(Deserialize)]
+pub struct InitConf {
+    pub options: serde_json::Value,
+    pub configuration: ConfFiled,
+}
+
+#[derive(Deserialize)]
+pub struct ConfFiled {
+    #[serde(rename = "lightning-dir")]
+    pub lightning_dir: String,
+    #[serde(rename = "rpc-file")]
+    pub rpc_file: String,
+    pub startup: bool,
+    pub network: String,
+    pub feature_set: HashMap<String, String>,
+    pub proxy: ProxyInfo,
+    #[serde(rename = "torv3-enabled")]
+    pub torv3_enabled: bool,
+    pub always_use_proxy: bool,
+}
+
+#[derive(Deserialize)]
+pub struct ProxyInfo {
+    #[serde(alias = "type")]
+    pub tup: String,
+    pub address: String,
+    pub port: i64,
+}

--- a/plugin/src/commands/types.rs
+++ b/plugin/src/commands/types.rs
@@ -14,6 +14,13 @@ pub struct RPCMethodInfo {
     pub deprecated: bool,
 }
 
+#[derive(Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct RPCHookInfo {
+    pub name: String,
+    pub before: Option<Vec<String>>,
+    pub after: Option<Vec<String>>,
+}
+
 #[derive(Deserialize)]
 pub struct InitConf {
     pub options: serde_json::Value,

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -1,8 +1,10 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}
+//! plugin crater provide the building blocks to build
+//! plugin in c-lightning in a modular way.
+//!
+//! ### Ecosystem feature
+//! * **clightningrpc** -
+//!  When enable provide the typed API to the plugin
+//!
+//! author and mantainer: Vincenzo Palazzo https://github.com/vincenzopalazzo
+
+pub mod plugin;

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -1,10 +1,12 @@
 //! plugin crater provide the building blocks to build
-//! plugin in c-lightning in a modular way.
+//! plugin in core lightning in a modular way.
 //!
 //! ### Ecosystem feature
 //! * **clightningrpc** -
 //!  When enable provide the typed API to the plugin
 //!
 //! author and mantainer: Vincenzo Palazzo https://github.com/vincenzopalazzo
-
+#![crate_name = "clightningrpc_plugin"]
+pub mod commands;
 pub mod plugin;
+pub mod types;

--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -1,0 +1,11 @@
+//! Core of the plugin API
+
+pub trait Plugin {
+    /// Main function that start the handshake process
+    /// with c-lightning
+    fn start(&self) {
+        // TODO start here the process of the handshake
+        // so the API should provide a default implementation
+        // of this method
+    }
+}

--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -1,11 +1,133 @@
 //! Core of the plugin API
+//!
+//! Unofficial API interface to develop plugin in Rust.
+use crate::commands::{
+    builtin::{InitRPC, ManifestRPC},
+    types::RPCMethodInfo,
+    RPCMethod,
+};
+use crate::types::RpcOption;
 
-pub trait Plugin {
-    /// Main function that start the handshake process
-    /// with c-lightning
-    fn start(&self) {
-        // TODO start here the process of the handshake
-        // so the API should provide a default implementation
-        // of this method
+use crate::commands::json_utils::init_success_response;
+use clightningrpc_common::types::Request;
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::string::String;
+
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct Plugin<T>
+where
+    T: Clone,
+{
+    state: T,
+    /// all the option contained inside the
+    /// hash map.
+    pub option: HashSet<RpcOption>,
+    /// all the options rpc method that the
+    /// plugin need to support, included the builtin rpc method.
+    pub rpc_method: HashMap<String, Box<dyn RPCMethod<T>>>,
+    /// keep the info of the method in a separate list
+    /// FIXME: move the RPCMethodInfo as key of the rpc_method map.
+    pub rpc_info: HashSet<RPCMethodInfo>,
+    /// mark a plugin as dynamic, in this way the plugin can be run
+    /// from core lightning without stop the lightningd deamon
+    pub dynamic: bool,
+}
+
+impl<'a, T: 'a + Clone> Plugin<T> {
+    pub fn new(state: T, dynamic: bool) -> Self {
+        return Plugin {
+            state,
+            option: HashSet::new(),
+            rpc_method: HashMap::new(),
+            rpc_info: HashSet::new(),
+            dynamic,
+        };
+    }
+
+    pub fn log(&self) -> &Self {
+        todo!()
+    }
+
+    pub fn add_opt(
+        &mut self,
+        name: &str,
+        opt_type: &str,
+        def_val: Option<String>,
+        description: &str,
+        deprecated: bool,
+    ) -> &mut Self {
+        self.option.insert(RpcOption {
+            name: name.to_string(),
+            opt_typ: opt_type.to_string(),
+            default: def_val,
+            description: description.to_string(),
+            deprecated,
+        });
+        self
+    }
+
+    //TODO: adding the long description as parameter
+    // FIXME: see if with the macros the API can be improved
+    pub fn add_rpc_method<F: 'static>(
+        &'a mut self,
+        name: &str,
+        usage: &str,
+        description: &str,
+        callback: F,
+    ) -> &mut Self
+    where
+        F: RPCMethod<T> + 'static,
+    {
+        self.rpc_method.insert(name.to_owned(), Box::new(callback));
+        self.rpc_info.insert(RPCMethodInfo {
+            name: name.to_string(),
+            usage: usage.to_string(),
+            description: description.to_string(),
+            long_description: description.to_string(),
+            deprecated: false,
+        });
+        self
+    }
+
+    fn call_rpc_method(&'a mut self, name: &str, params: &serde_json::Value) -> serde_json::Value {
+        let command = self.rpc_method.get(name).unwrap().clone();
+        command.call(self, params)
+    }
+
+    pub fn register_hook(&mut self) -> &mut Self {
+        todo!()
+    }
+
+    pub fn register_notification(&mut self) -> &mut Self {
+        todo!()
+    }
+
+    pub fn start(&'a mut self) {
+        let writer = io::stdin();
+        let mut buffer = String::new();
+
+        self.rpc_method
+            .insert("getmanifest".to_owned(), Box::new(ManifestRPC {}));
+        self.rpc_method
+            .insert("init".to_owned(), Box::new(InitRPC {}));
+        // FIXME: core lightning end with the double endline, so this can cause
+        // problem for some input reader.
+        // we need to parse the writer, and avoid this while loop
+        loop {
+            let _ = writer.read_line(&mut buffer);
+            let req_str = buffer.to_string();
+            if req_str.trim().is_empty() {
+                continue;
+            }
+            buffer.clear();
+            let request: Request<serde_json::Value> = serde_json::from_str(&req_str).unwrap();
+            let response = self.call_rpc_method(request.method, &request.params);
+            let mut rpc_response = init_success_response(request.id);
+            rpc_response["result"] = response;
+            // TODO: improve the stout writing!
+            println!("{}", serde_json::to_string(&rpc_response).unwrap());
+        }
     }
 }

--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -5,7 +5,7 @@ use crate::commands::json_utils::{add_str, init_success_response};
 use crate::commands::{
     builtin::{InitRPC, ManifestRPC},
     types::{RPCHookInfo, RPCMethodInfo},
-    RPCMethod,
+    RPCCommand,
 };
 use crate::types::{LogLevel, RpcOption};
 use clightningrpc_common::types::Request;
@@ -25,17 +25,17 @@ where
     pub option: HashSet<RpcOption>,
     /// all the options rpc method that the
     /// plugin need to support, included the builtin rpc method.
-    pub rpc_method: HashMap<String, Box<dyn RPCMethod<T>>>,
+    pub rpc_method: HashMap<String, Box<dyn RPCCommand<T>>>,
     /// keep the info of the method in a separate list
     /// FIXME: move the RPCMethodInfo as key of the rpc_method map.
     pub rpc_info: HashSet<RPCMethodInfo>,
     /// all the hook where the plugin is register during the configuration
-    pub rpc_hook: HashMap<String, Box<dyn RPCMethod<T>>>,
+    pub rpc_hook: HashMap<String, Box<dyn RPCCommand<T>>>,
     /// keep all the info about the hooks in a separate set.
     /// FIXME: put the RPCHookInfo as key of the hash map.
     pub hook_info: HashSet<RPCHookInfo>,
     /// all the notification that the plugin is register on
-    pub rpc_nofitication: HashMap<String, Box<dyn RPCMethod<T>>>,
+    pub rpc_nofitication: HashMap<String, Box<dyn RPCCommand<T>>>,
     /// mark a plugin as dynamic, in this way the plugin can be run
     /// from core lightning without stop the lightningd deamon
     pub dynamic: bool,
@@ -94,7 +94,7 @@ impl<'a, T: 'a + Clone> Plugin<T> {
         callback: F,
     ) -> &mut Self
     where
-        F: RPCMethod<T> + 'static,
+        F: RPCCommand<T> + 'static,
     {
         self.rpc_method.insert(name.to_owned(), Box::new(callback));
         self.rpc_info.insert(RPCMethodInfo {
@@ -120,7 +120,7 @@ impl<'a, T: 'a + Clone> Plugin<T> {
         callback: F,
     ) -> &mut Self
     where
-        F: RPCMethod<T> + 'static,
+        F: RPCCommand<T> + 'static,
     {
         self.rpc_hook
             .insert(hook_name.to_owned(), Box::new(callback));
@@ -134,7 +134,7 @@ impl<'a, T: 'a + Clone> Plugin<T> {
 
     pub fn register_notification<F: 'static>(&mut self, name: &str, callback: F) -> &mut Self
     where
-        F: 'static + RPCMethod<T> + Clone,
+        F: 'static + RPCCommand<T> + Clone,
     {
         self.rpc_nofitication
             .insert(name.to_owned(), Box::new(callback));

--- a/plugin/src/types.rs
+++ b/plugin/src/types.rs
@@ -1,0 +1,20 @@
+//! types
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Clone, Eq, Hash, PartialEq)]
+pub struct RpcOption {
+    /// option name that is specified by the
+    /// core lightning user, like --foo
+    pub name: String,
+    /// option type, that can be specified like the enum
+    #[serde(rename = "type")]
+    pub opt_typ: String,
+    /// default value, that can be specified only as string
+    /// and core lightning will convert it for you :) smart right?
+    pub default: Option<String>,
+    /// description of the option that is shows to the user
+    /// when lightningd --help is typed
+    pub description: String,
+    /// if the filed is deprecated
+    pub deprecated: bool,
+}

--- a/plugin/src/types.rs
+++ b/plugin/src/types.rs
@@ -1,5 +1,6 @@
 //! types
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 #[derive(Deserialize, Serialize, Clone, Eq, Hash, PartialEq)]
 pub struct RpcOption {
@@ -17,4 +18,18 @@ pub struct RpcOption {
     pub description: String,
     /// if the filed is deprecated
     pub deprecated: bool,
+}
+
+pub enum LogLevel {
+    Debug,
+    Info,
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LogLevel::Debug => write!(f, "debug"),
+            LogLevel::Info => write!(f, "info"),
+        }
+    }
 }


### PR DESCRIPTION
This is my second attempt that implements the Plugin API, this will use the Command pattern to implement a callback, instead to create a function type.

This IMHO makes the code more readble, also with rust.