### PR TITLE
ci: add release process with github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
-on: [push, pull_request]
-
 name: Sanity Check codebase
+
+on: [push, pull_request]
 
 jobs:
   check:

--- a/.github/workflows/release_comm.yml
+++ b/.github/workflows/release_comm.yml
@@ -1,0 +1,33 @@
+name: common crate release
+
+on:
+  release:
+    types: [created]
+    tags:
+      - common-v*
+  push:
+  pull_request:
+  workflow_run:
+    workflows:
+      - "Sanity Check codebase"
+      - "Integration testing"
+    branches: [ master ]
+    types:
+      - completed
+
+jobs:
+  publishing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v1
+        with:
+          #registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          path: './common'
+          ignore-unpublished-changes: true
+          check-repo: ${{ github.event_name == 'push' }}
+          dry-run: ${{ github.event_name == 'push' }}

--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -1,0 +1,33 @@
+name: plugin crate release
+
+on:
+  release:
+    types: [created]
+    tags:
+      - rpc-v*
+  push:
+  pull_request:
+  workflow_run:
+    workflows:
+      - "Sanity Check codebase"
+      - "Integration testing"
+    branches: [ master ]
+    types:
+      - completed
+
+jobs:
+  publishing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v1
+        with:
+          #registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          path: './plugin'
+          ignore-unpublished-changes: true
+          check-repo: ${{ github.event_name == 'push' }}
+          dry-run: ${{ github.event_name == 'push' }}

--- a/.github/workflows/release_rpc.yml
+++ b/.github/workflows/release_rpc.yml
@@ -1,0 +1,33 @@
+name: rpc crate release
+
+on:
+  release:
+    types: [created]
+    tags:
+      - rpc-v*
+  push:
+  pull_request:
+  workflow_run:
+    workflows:
+      - "Sanity Check codebase"
+      - "Integration testing"
+    branches: [ master ]
+    types:
+      - completed
+
+jobs:
+  publishing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v1
+        with:
+          #registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          path: './rpc'
+          ignore-unpublished-changes: true
+          check-repo: ${{ github.event_name == 'push' }}
+          dry-run: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
This PR is a starting work for keeping the release process stuck in the CI, and with the possibility to choose what package release with just a prefix in the release tag.

Required more work, and also a way to define a changelog

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>