### PR TITLE
Make generic `fn call` pub

### DIFF
--- a/rpc/src/lightningrpc.rs
+++ b/rpc/src/lightningrpc.rs
@@ -56,7 +56,11 @@ impl LightningRPC {
     }
 
     /// Generic call function for RPC calls.
-    fn call<T: Serialize, U: DeserializeOwned>(&self, method: &str, input: T) -> Result<U, Error> {
+    pub fn call<T: Serialize, U: DeserializeOwned>(
+        &self,
+        method: &str,
+        input: T,
+    ) -> Result<U, Error> {
         self.client
             .send_request(method, input)
             .and_then(|res| res.into_result())


### PR DESCRIPTION
`call` should ideally be private but there could be breaking changes in the JSON format preventing us to access some API.
In those cases this would enable to call the API with `Value`, for example:
`client.call::<Value, Value>("getinfo", json!([]))`

In my specific case I have the following json that fails to parse with `client.getinfo()` because the field `fees_collected_msat` is number instead of string with "msat"

```json
{
  "address": [],
  "alias": "JUNIORBEAM-v0.11.2gl2",
  "binding": [
    {
      "address": "127.0.0.1",
      "port": 34123,
      "type": "ipv4"
    }
  ],
  "blockheight": 102,
  "color": "0266e4",
  "fees_collected_msat": 0,
  "id": "0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518",
  "lightning-dir": "/tmp/tmpbtxj5n19/lightning-1/regtest",
  "network": "regtest",
  "num_active_channels": 0,
  "num_inactive_channels": 0,
  "num_peers": 0,
  "num_pending_channels": 0,
  "our_features": {
    "channel": "",
    "init": "088000080269a2",
    "invoice": "02000000024100",
    "node": "888000080269a2"
  },
  "version": "v0.11.2gl2"
}
``` 