### PR TITLE
plugin: don't panic on BrokenPipe when lightningd has died

### DIFF
--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -120,10 +120,11 @@ impl<'a, T: 'a + Clone> Plugin<T> {
             method: "log".to_owned(),
             params: payload,
         };
-        writer
-            .write_all(serde_json::to_string(&request).unwrap().as_bytes())
-            .unwrap();
-        writer.flush().unwrap();
+        // Best-effort: if the parent (lightningd) has gone away the write
+        // will fail with BrokenPipe. Drop the error rather than panic — the
+        // main read loop will observe EOF on stdin and exit cleanly.
+        let _ = writer.write_all(serde_json::to_string(&request).unwrap().as_bytes());
+        let _ = writer.flush();
     }
 
     /// register the plugin option.
@@ -290,10 +291,18 @@ impl<'a, T: 'a + Clone> Plugin<T> {
                 let response = self.call_rpc_method(&request.method, request.params);
                 let mut rpc_response = init_success_response(id);
                 self.write_respose(&response, &mut rpc_response);
-                writer
+                // If the write fails the parent (lightningd) has gone away;
+                // exit cleanly instead of panicking on BrokenPipe. The next
+                // read_line will return EOF and break the outer loop too.
+                if writer
                     .write_all(serde_json::to_string(&rpc_response).unwrap().as_bytes())
-                    .unwrap();
-                writer.flush().unwrap();
+                    .is_err()
+                {
+                    break;
+                }
+                if writer.flush().is_err() {
+                    break;
+                }
             } else {
                 // in case of the id is None, we are receiving the notification, so the server is not
                 // interested in the answer.


### PR DESCRIPTION
## Summary

- `Plugin::log()` and the response-writing path in `Plugin::start()` both call `.unwrap()` on writes to stdout. When `lightningd` exits or closes the pipe between the plugin reading a request and writing back, the unwrap panics with `BrokenPipe` instead of letting the plugin exit cleanly.
- Make both writers best-effort: in `log()` we swallow the error (logs are lossy by design), and in `start()` we break out of the read loop so the plugin terminates cleanly. On a healthy parent the behavior is unchanged — the subsequent `read_line` would have returned `Ok(0)` and broken the loop anyway.

## Background

Observed in the wild while running [folgore](https://github.com/coffee-tools/folgore) under CLN v25.09.3 on a low-RAM host. When `lightningd` died for any reason (fatal signal, OOM kill), one or more `folgore_plugin` Rust processes were left as orphans, spinning on stdin in an empty read loop or — worse — having panicked on a half-written response and exited mid-state.

The EOF check on `read_line` already added in 4f8df9a covers the "parent closed our stdin" case, but only after a clean iteration. If the parent dies between request and response, the `unwrap` fires first.

After applying both fixes locally and verifying via `[patch.crates-io]` against the actual `folgore_plugin` binary across multiple `lightningd` death cycles: zero orphan plugin processes, clean exits every time.

## Test plan

- [ ] `cargo build --release -p clightningrpc-plugin`
- [ ] Existing test suite passes (`cargo test`)
- [ ] Manual: run any plugin built against this branch, kill `lightningd` with SIGKILL, confirm the plugin exits within one stdin read cycle rather than panicking or orphaning

🤖 Generated with [Claude Code](https://claude.com/claude-code)